### PR TITLE
Migrating the mysql package to mysql2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "isbot": "^3.5.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
-    "mysql": "^2.18.1",
+    "mysql2": "^2.3.3",
     "nestjs-telegraf": "^2.6.0",
     "newrelic": "^9.0.0",
     "otplib": "^12.0.1",


### PR DESCRIPTION
Fixed an error:
```bash
ER_NOT_SUPPORTED_AUTH_MODE: Client does not support authentication protocol requested by server; consider upgrading MySQL client
```

The error occurred at startup.