### PR TITLE
(fix) Eliminated 'Host Header poisoning' vulnerability

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -39,6 +39,7 @@ const clickhouse = new ClickHouse({
 })
 
 const isSelfhosted = Boolean(process.env.SELFHOSTED)
+const isDevelopment = process.env.NODE_ENV === 'development'
 const isNewRelicEnabled = Boolean(process.env.USE_NEW_RELIC)
 
 const CLICKHOUSE_INIT_QUERIES = [
@@ -193,6 +194,8 @@ const SEND_WARNING_AT_PERC = 85
 
 const PROJECT_INVITE_EXPIRE = 48
 
+const PRODUCTION_ORIGIN = 'https://swetrix.com'
+
 export {
   clickhouse,
   JWT_LIFE_TIME,
@@ -226,4 +229,6 @@ export {
   ORIGINS_REGEX,
   REDIS_LOG_PERF_CACHE_KEY,
   REDIS_PERFORMANCE_COUNT_KEY,
+  isDevelopment,
+  PRODUCTION_ORIGIN,
 }

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -48,6 +48,8 @@ import {
   clickhouse,
   isSelfhosted,
   PROJECT_INVITE_EXPIRE,
+  isDevelopment,
+  PRODUCTION_ORIGIN,
 } from '../common/constants'
 import {
   getProjectsClickhouse,
@@ -695,7 +697,7 @@ export class ProjectController {
         ActionTokenType.PROJECT_SHARE,
         share.id,
       )
-      const url = `${headers.origin}/share/${actionToken.id}`
+      const url = `${isDevelopment ? headers.origin : PRODUCTION_ORIGIN}/share/${actionToken.id}`
       await this.mailerService.sendEmail(
         invitee.email,
         LetterTemplate.ProjectInvitation,
@@ -838,7 +840,7 @@ export class ProjectController {
       projectName: project.name,
       email: body.email,
       reportFrequency: body.reportFrequency,
-      origin: headers.origin,
+      origin: isDevelopment ? headers.origin : PRODUCTION_ORIGIN,
     })
   }
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -46,6 +46,8 @@ import {
   isSelfhosted,
   SELFHOSTED_UUID,
   SELFHOSTED_EMAIL,
+  isDevelopment,
+  PRODUCTION_ORIGIN,
 } from '../common/constants'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { SelfhostedGuard } from '../common/guards/selfhosted.guard'
@@ -388,7 +390,7 @@ export class UserController {
       ActionTokenType.EMAIL_VERIFICATION,
       user.email,
     )
-    const url = `${request.headers.origin}/verify/${token.id}`
+    const url = `${isDevelopment ? request.headers.origin : PRODUCTION_ORIGIN}/verify/${token.id}`
 
     await this.userService.update(id, { emailRequests: 1 + user.emailRequests })
     await this.mailerService.sendEmail(user.email, LetterTemplate.SignUp, {
@@ -490,7 +492,7 @@ export class UserController {
           ActionTokenType.EMAIL_CHANGE,
           userDTO.email,
         )
-        const url = `${request.headers.origin}/change-email/${token.id}`
+        const url = `${isDevelopment ? request.headers.origin : PRODUCTION_ORIGIN}/change-email/${token.id}`
         await this.mailerService.sendEmail(
           user.email,
           LetterTemplate.MailAddressChangeConfirmation,


### PR DESCRIPTION
An attacker might have spoofed the `origin` header in the reset form and, for instance, password reset link that would be sent to user would contain a malicious link to the attackers website, that could potentially lead to leaking user's passwords.

This patch fixes this vulnerability and limits `origin` links to the development environments only.

https://portswigger.net/web-security/host-header