### PR TITLE
Set redis `options.family` to `0`

### DIFF
--- a/apps/production/src/common/constants.ts
+++ b/apps/production/src/common/constants.ts
@@ -16,6 +16,7 @@ const redis = new Redis(
   {
     password: process.env.REDIS_PASSWORD,
     username: process.env.REDIS_USER,
+    family: 0,
   },
 )
 

--- a/apps/selfhosted/src/common/constants.ts
+++ b/apps/selfhosted/src/common/constants.ts
@@ -15,6 +15,7 @@ const redis = new Redis(
   {
     password: process.env.REDIS_PASSWORD,
     username: process.env.REDIS_USER,
+    family: 0,
   },
 )
 


### PR DESCRIPTION
Please describe your changes using the checklist below.

Some Hosts like Railway and Fly have internal networks that are IPv6 only, without this ioredis will only use IPv4, when set to `0` both IPv6 and IPv4 will be used.

### Self-hosted support
- [y] Your feature is implemented for the selfhosted version of Swetrix
- [?] This PR only updates the production code (e.g. paddle webhooks, CAPTCHA, blog, etc.)

### Database migrations
- [n] Clickhouse / MySQL migrations added for this PR
- [y] No table schemas changed in this PR

### Documentation
- [n/a] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [y] This PR did not change any publicly documented endpoints
