### PR TITLE
(fix) Data exists & is locked flags for shared projects

### DIFF
--- a/apps/production/src/project/entity/project-share.entity.ts
+++ b/apps/production/src/project/entity/project-share.entity.ts
@@ -22,19 +22,31 @@ export class ProjectShare {
   @PrimaryGeneratedColumn('uuid')
   id: string
 
+  /**
+   * User whom with the project was shared
+   */
   @ApiProperty({ type: () => User })
   @ManyToOne(() => User, user => user.sharedProjects)
   user: User
 
+  /**
+   * Project in question
+   */
   @ManyToOne(() => Project, project => project.share)
   project: Project
 
+  /**
+   * Boolean indicating whether the user accepted project invitation
+   */
   @ApiProperty()
   @Column({
     default: false,
   })
   confirmed: boolean
 
+  /**
+   * User's role in the project
+   */
   @Column({
     type: 'enum',
     enum: Role,

--- a/apps/production/src/project/project.controller.ts
+++ b/apps/production/src/project/project.controller.ts
@@ -244,6 +244,22 @@ export class ProjectController {
       where,
     )
 
+    const pidsWithData =
+      await this.projectService.getPIDsWhereAnalyticsDataExists(
+        _map(paginated.results, ({ project }) => project.id),
+      )
+
+    paginated.results = _map(paginated.results, share => ({
+      ...share,
+      project: {
+        ...share.project,
+        admin: undefined,
+        passwordHash: undefined,
+        isLocked: !!share?.project?.admin?.dashboardBlockReason,
+        isDataExists: _includes(pidsWithData, share?.project?.id),
+      },
+    }))
+
     return paginated
   }
 

--- a/apps/production/src/project/project.service.ts
+++ b/apps/production/src/project/project.service.ts
@@ -368,11 +368,10 @@ export class ProjectService {
       order: {
         project: 'ASC',
       },
-      relations: ['project'],
+      relations: ['project', 'project.admin'],
     })
 
     return new Pagination<ProjectShare>({
-      // results: processProjectsUser(results),
       results,
       total,
     })


### PR DESCRIPTION
Please describe your changes using the checklist below.

### Self-hosted support
- [ ] Your feature is implemented for the selfhosted version of Swetrix
- [x] This PR only updates the production code (e.g. paddle webhooks, CAPTCHA, blog, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints
