### PR TITLE
(improvement) Migrate from `clickhouse` to `@clickhouse/client`

### DIFF
--- a/apps/production/src/analytics/analytics.controller.ts
+++ b/apps/production/src/analytics/analytics.controller.ts
@@ -3,11 +3,8 @@ import * as _isArray from 'lodash/isArray'
 import * as _toNumber from 'lodash/toNumber'
 import * as _pick from 'lodash/pick'
 import * as _includes from 'lodash/includes'
-import * as _keys from 'lodash/keys'
-import * as _values from 'lodash/values'
 import * as _map from 'lodash/map'
 import * as _uniqBy from 'lodash/uniqBy'
-import * as _round from 'lodash/round'
 import * as dayjs from 'dayjs'
 import * as utc from 'dayjs/plugin/utc'
 import * as dayjsTimezone from 'dayjs/plugin/timezone'
@@ -57,16 +54,12 @@ import { GetUserFlowDTO } from './dto/getUserFlow.dto'
 import { GetFunnelsDTO } from './dto/getFunnels.dto'
 import { AppLoggerService } from '../logger/logger.service'
 import {
-  REDIS_LOG_DATA_CACHE_KEY,
-  REDIS_LOG_PERF_CACHE_KEY,
   redis,
-  REDIS_LOG_CUSTOM_CACHE_KEY,
   HEARTBEAT_SID_LIFE_TIME,
   REDIS_USERS_COUNT_KEY,
   REDIS_PROJECTS_COUNT_KEY,
   REDIS_EVENTS_COUNT_KEY,
   REDIS_SESSION_SALT_KEY,
-  REDIS_LOG_ERROR_CACHE_KEY,
 } from '../common/constants'
 import { clickhouse } from '../common/integrations/clickhouse'
 import {
@@ -91,11 +84,13 @@ import { ErrorDTO } from './dto/error.dto'
 import { GetErrorsDto } from './dto/get-errors.dto'
 import { GetErrorDTO } from './dto/get-error.dto'
 import { PatchStatusDTO } from './dto/patch-status.dto'
-import { ProjectService } from '../project/project.service'
 import { ProjectsViewsRepository } from '../project/repositories/projects-views.repository'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const mysql = require('mysql2')
+import {
+  customEventTransformer,
+  errorEventTransformer,
+  performanceTransformer,
+  trafficTransformer,
+} from './utils/transformers'
 
 dayjs.extend(utc)
 dayjs.extend(dayjsTimezone)
@@ -109,177 +104,6 @@ const getSessionKeyCustom = (
   ev: string,
   salt = '',
 ) => `cses_${hash(`${ua}${ip}${pid}${ev}${salt}`).toString('hex')}`
-
-const analyticsDTO = (
-  psid: string,
-  sid: string,
-  pid: string,
-  pg: string,
-  prev: string,
-  dv: string,
-  br: string,
-  os: string,
-  lc: string,
-  ref: string,
-  so: string,
-  me: string,
-  ca: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  keys: string[],
-  values: string[],
-  sdur: number | string,
-  unique: number,
-): Array<string | number | string[]> => {
-  return [
-    psid,
-    sid,
-    pid,
-    pg,
-    prev,
-    dv,
-    br,
-    os,
-    lc,
-    ref,
-    so,
-    me,
-    ca,
-    cc,
-    rg,
-    ct,
-    keys,
-    values,
-    sdur,
-    unique,
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const performanceDTO = (
-  pid: string,
-  pg: string,
-  dv: string,
-  br: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  dns: number,
-  tls: number,
-  conn: number,
-  response: number,
-  render: number,
-  domLoad: number,
-  pageLoad: number,
-  ttfb: number,
-): Array<string | number> => {
-  return [
-    pid,
-    pg,
-    dv,
-    br,
-    cc,
-    rg,
-    ct,
-    _round(dns),
-    _round(tls),
-    _round(conn),
-    _round(response),
-    _round(render),
-    _round(domLoad),
-    _round(pageLoad),
-    _round(ttfb),
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const customLogDTO = (
-  psid: string,
-  pid: string,
-  ev: string,
-  pg: string,
-  dv: string,
-  br: string,
-  os: string,
-  lc: string,
-  ref: string,
-  so: string,
-  me: string,
-  ca: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  keys: string[],
-  values: string[],
-): Array<string | number | string[]> => {
-  return [
-    psid,
-    pid,
-    ev,
-    pg,
-    dv,
-    br,
-    os,
-    lc,
-    ref,
-    so,
-    me,
-    ca,
-    cc,
-    rg,
-    ct,
-    keys,
-    values,
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const errorLogDTO = (
-  eid: string,
-  pid: string,
-  pg: string,
-  dv: string,
-  br: string,
-  os: string,
-  lc: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  name: string,
-  message: string,
-  lineno: number,
-  colno: number,
-  filename: string,
-): Array<string | number | string[]> => {
-  return [
-    eid,
-    pid,
-    pg,
-    dv,
-    br,
-    os,
-    lc,
-    cc,
-    rg,
-    ct,
-    name,
-    message,
-    lineno,
-    colno,
-    filename,
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-export const getElValue = el => {
-  if (_isArray(el)) {
-    return `[${_map(el, getElValue).join(',')}]`
-  }
-
-  if (el === undefined || el === null || el === 'NULL') return 'NULL'
-  return mysql.escape(el)
-}
 
 // Performance object validator: none of the values cannot be bigger than 1000 * 60 * 5 (5 minutes) and are >= 0
 const MAX_PERFORMANCE_VALUE = 1000 * 60 * 5
@@ -370,7 +194,6 @@ export class AnalyticsController {
   constructor(
     private readonly analyticsService: AnalyticsService,
     private readonly logger: AppLoggerService,
-    private readonly projectService: ProjectService,
     private readonly projectsViewsRepository: ProjectsViewsRepository,
   ) {}
 
@@ -1285,7 +1108,7 @@ export class AnalyticsController {
 
     const { name, message, lineno, colno, filename } = errorDTO
 
-    const dto = errorLogDTO(
+    const transformed = errorEventTransformer(
       this.analyticsService.getErrorID(errorDTO),
       errorDTO.pid,
       errorDTO.pg,
@@ -1304,8 +1127,14 @@ export class AnalyticsController {
     )
 
     try {
-      const values = `(${dto.map(getElValue).join(',')})`
-      await redis.rpush(REDIS_LOG_ERROR_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'errors',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
     } catch (e) {
       this.logger.error(e)
       throw new InternalServerErrorException(
@@ -1389,7 +1218,7 @@ export class AnalyticsController {
     const sessionHash = getSessionKey(ip, userAgent, eventsDTO.pid, salt)
     const [, psid] = await this.analyticsService.isUnique(sessionHash)
 
-    const dto = customLogDTO(
+    const transformed = customEventTransformer(
       psid,
       eventsDTO.pid,
       eventsDTO.ev,
@@ -1405,13 +1234,18 @@ export class AnalyticsController {
       country,
       region,
       city,
-      _keys(eventsDTO.meta),
-      _values(eventsDTO.meta),
+      eventsDTO.meta,
     )
 
     try {
-      const values = `(${dto.map(getElValue).join(',')})`
-      await redis.rpush(REDIS_LOG_CUSTOM_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'customEV',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
     } catch (e) {
       this.logger.error(e)
       throw new InternalServerErrorException(
@@ -1476,17 +1310,13 @@ export class AnalyticsController {
       )
     }
 
-    const {
-      city = 'NULL',
-      region = 'NULL',
-      country = 'NULL',
-    } = getGeoDetails(ip, logDTO.tz)
+    const { city, region, country } = getGeoDetails(ip, logDTO.tz)
     const ua = UAParser(userAgent)
     const dv = ua.device.type || 'desktop'
     const br = ua.browser.name
     const os = ua.os.name
 
-    const dto = analyticsDTO(
+    const transformed = trafficTransformer(
       psid,
       sessionHash,
       logDTO.pid,
@@ -1503,13 +1333,12 @@ export class AnalyticsController {
       country,
       region,
       city,
-      _keys(logDTO.meta),
-      _values(logDTO.meta),
+      logDTO.meta,
       0,
       Number(unique),
     )
 
-    let perfDTO: Array<string | number> = []
+    let perfTransformed = null
 
     if (!_isEmpty(logDTO.perf) && isPerformanceValid(logDTO.perf)) {
       const {
@@ -1523,7 +1352,7 @@ export class AnalyticsController {
         ttfb,
       } = logDTO.perf
 
-      perfDTO = performanceDTO(
+      perfTransformed = performanceTransformer(
         logDTO.pid,
         logDTO.pg,
         dv,
@@ -1542,14 +1371,25 @@ export class AnalyticsController {
       )
     }
 
-    const values = `(${dto.map(getElValue).join(',')})`
-
     try {
-      await redis.rpush(REDIS_LOG_DATA_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'analytics',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
 
-      if (!_isEmpty(perfDTO)) {
-        const perfValues = `(${perfDTO.map(getElValue).join(',')})`
-        await redis.rpush(REDIS_LOG_PERF_CACHE_KEY, perfValues)
+      if (!_isEmpty(perfTransformed)) {
+        await clickhouse.insert({
+          table: 'performance',
+          format: 'JSONEachRow',
+          values: [perfTransformed],
+          clickhouse_settings: {
+            async_insert: 1,
+          },
+        })
       }
     } catch (e) {
       this.logger.error(e)
@@ -1602,32 +1442,37 @@ export class AnalyticsController {
     const br = ua.browser.name
     const os = ua.os.name
 
-    const dto = analyticsDTO(
+    const transformed = trafficTransformer(
       psid,
       sessionHash,
       logDTO.pid,
-      'NULL',
-      'NULL',
+      null,
+      null,
       dv,
       br,
       os,
-      'NULL',
-      'NULL',
-      'NULL',
-      'NULL',
-      'NULL',
+      null,
+      null,
+      null,
+      null,
+      null,
       country,
       region,
       city,
-      [],
-      [],
+      null,
       0,
       Number(unique),
     )
 
-    const values = `(${dto.map(getElValue).join(',')})`
     try {
-      await redis.rpush(REDIS_LOG_DATA_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'analytics',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
     } catch (e) {
       this.logger.error(e)
     }

--- a/apps/production/src/analytics/analytics.controller.ts
+++ b/apps/production/src/analytics/analytics.controller.ts
@@ -66,9 +66,9 @@ import {
   REDIS_PROJECTS_COUNT_KEY,
   REDIS_EVENTS_COUNT_KEY,
   REDIS_SESSION_SALT_KEY,
-  clickhouse,
   REDIS_LOG_ERROR_CACHE_KEY,
 } from '../common/constants'
+import { clickhouse } from '../common/integrations/clickhouse'
 import {
   checkRateLimit,
   getGeoDetails,
@@ -1220,11 +1220,11 @@ export class AnalyticsController {
   @Get('liveVisitors')
   @Auth([], true, true)
   async getLiveVisitors(
-    @Query() data,
+    @Query() queryParams,
     @CurrentUserId() uid: string,
     @Headers() headers: { 'x-password'?: string },
   ): Promise<object> {
-    const { pid } = data
+    const { pid } = queryParams
 
     this.analyticsService.validatePID(pid)
     await this.analyticsService.checkProjectAccess(
@@ -1246,8 +1246,10 @@ export class AnalyticsController {
     const query = `SELECT sid, dv, br, os, cc FROM analytics WHERE sid IN (${sids
       .map(el => `'${el}'`)
       .join(',')})`
-    const result = await clickhouse.query(query).toPromise()
-    const processed = _map(_uniqBy(result, 'sid'), el =>
+    const { data } = await clickhouse
+      .query({ query })
+      .then(resultSet => resultSet.json())
+    const processed = _map(_uniqBy(data, 'sid'), el =>
       _pick(el, ['dv', 'br', 'os', 'cc']),
     )
 

--- a/apps/production/src/analytics/analytics.service.ts
+++ b/apps/production/src/analytics/analytics.service.ts
@@ -3708,28 +3708,24 @@ export class AnalyticsService {
     status: 'resolved' | 'active',
     pid: string,
   ) {
-    const params = _reduce(
+    const values = _reduce(
       eids,
-      (acc, curr, index) => ({
+      (acc, curr) => [
         ...acc,
-        [`e_${index}`]: curr,
-      }),
-      {},
-    )
-
-    const query = `INSERT INTO error_statuses (eid, pid, status) VALUES ${_map(
-      params,
-      (val, key) =>
-        `({${key}:FixedString(32)}, {pid:FixedString(12)}, '${status}')`,
-    ).join(', ')}`
-
-    try {
-      await clickhouse.query({
-        query,
-        query_params: {
-          ...params,
+        {
+          eid: curr,
+          status,
           pid,
         },
+      ],
+      [],
+    )
+
+    try {
+      await clickhouse.insert({
+        table: 'error_statuses',
+        format: 'JSONEachRow',
+        values: [values],
       })
     } catch (reason) {
       console.error('Error at PATCH error-status:')

--- a/apps/production/src/analytics/analytics.service.ts
+++ b/apps/production/src/analytics/analytics.service.ts
@@ -826,7 +826,7 @@ export class AnalyticsService {
     const { data: from } = await clickhouse
       .query({
         query:
-          'SELECT created FROM analytics where pid = {pid:FixedString(12)} ORDER BY created ASC LIMIT 1',
+          'SELECT created FROM analytics WHERE pid = {pid:FixedString(12)} ORDER BY created ASC LIMIT 1',
         query_params: { pid },
       })
       .then(res => res.json<{ created?: string }>())
@@ -1004,7 +1004,9 @@ export class AnalyticsService {
           const keyParam = `qfk_${col}_${f}`
           params[keyParam] = key
 
-          query += `indexOf(meta.key, {${keyParam}:String}) > 0 AND meta.value[indexOf(meta.key, {${keyParam}:String})] ${isExclusive ? '!= ' : '='} {${param}:String}`
+          query += `indexOf(meta.key, {${keyParam}:String}) > 0 AND meta.value[indexOf(meta.key, {${keyParam}:String})] ${
+            isExclusive ? '!= ' : '='
+          } {${param}:String}`
           continue
         }
 
@@ -1030,7 +1032,9 @@ export class AnalyticsService {
         }
 
         query += isArrayDataset
-          ? `indexOf(${sqlColumn}, {${param}:String}) ${isExclusive ? '=' : '>'} 0`
+          ? `indexOf(${sqlColumn}, {${param}:String}) ${
+              isExclusive ? '=' : '>'
+            } 0`
           : `${isExclusive ? 'NOT ' : ''}${sqlColumn} = {${param}:String}`
       }
 
@@ -3344,6 +3348,7 @@ export class AnalyticsService {
           query_params: paramsData.params,
         })
         .then(resultSet => resultSet.json())
+        .then(({ data }) => data)
     )[0]
 
     if (!details) {
@@ -3365,6 +3370,7 @@ export class AnalyticsService {
             query_params: paramsData.params,
           })
           .then(resultSet => resultSet.json())
+          .then(({ data }) => data)
       )[0]
     }
 
@@ -3611,7 +3617,8 @@ export class AnalyticsService {
           query: queryErrorDetails,
           query_params: paramsData.params,
         })
-        .then(resultSet => resultSet.json())
+        .then(resultSet => resultSet.json<any>())
+        .then(({ data }) => data)
     )[0]
 
     const occurenceDetails = (
@@ -3620,7 +3627,8 @@ export class AnalyticsService {
           query: queryFirstLastSeen,
           query_params: paramsData.params,
         })
-        .then(resultSet => resultSet.json())
+        .then(resultSet => resultSet.json<any>())
+        .then(({ data }) => data)
     )[0]
 
     const groupedChart = await this.groupErrorsByTimeBucket(
@@ -3678,6 +3686,7 @@ export class AnalyticsService {
             query_params: { ...params, pid },
           })
           .then(resultSet => resultSet.json())
+          .then(({ data }) => data)
       )[0]
     } catch (reason) {
       console.error('validateEIDs - clickhouse request error')

--- a/apps/production/src/analytics/dto/events.dto.ts
+++ b/apps/production/src/analytics/dto/events.dto.ts
@@ -1,5 +1,6 @@
 import * as _keys from 'lodash/keys'
 import * as _values from 'lodash/values'
+import * as _some from 'lodash/some'
 import { ApiProperty } from '@nestjs/swagger'
 import {
   IsNotEmpty,
@@ -34,6 +35,15 @@ export class MetadataSizeLimit implements ValidatorConstraintInterface {
 export class MetadataKeysQuantity implements ValidatorConstraintInterface {
   validate(metadata: Record<string, string>) {
     return _keys(metadata).length <= MAX_METADATA_KEYS
+  }
+}
+
+@ValidatorConstraint()
+export class MetadataValueType implements ValidatorConstraintInterface {
+  validate(metadata: Record<string, string>) {
+    const values = _values(metadata)
+
+    return !_some(values, value => typeof value !== 'string')
   }
 }
 
@@ -114,6 +124,9 @@ export class EventsDTO {
   @IsObject()
   @Validate(MetadataKeysQuantity, {
     message: `Metadata object can't have more than ${MAX_METADATA_KEYS} keys`,
+  })
+  @Validate(MetadataValueType, {
+    message: 'All of metadata object values must be strings',
   })
   @Validate(MetadataSizeLimit, {
     message: `Metadata object can't have values with total length more than ${MAX_METADATA_VALUE_LENGTH} characters`,

--- a/apps/production/src/analytics/dto/pageviews.dto.ts
+++ b/apps/production/src/analytics/dto/pageviews.dto.ts
@@ -5,6 +5,7 @@ import {
   MAX_METADATA_KEYS,
   MAX_METADATA_VALUE_LENGTH,
   MetadataKeysQuantity,
+  MetadataValueType,
   MetadataSizeLimit,
 } from './events.dto'
 
@@ -107,6 +108,9 @@ export class PageviewsDTO {
   @IsObject()
   @Validate(MetadataKeysQuantity, {
     message: `Metadata object can't have more than ${MAX_METADATA_KEYS} keys`,
+  })
+  @Validate(MetadataValueType, {
+    message: 'All of metadata object values must be strings',
   })
   @Validate(MetadataSizeLimit, {
     message: `Metadata object can't have values with total length more than ${MAX_METADATA_VALUE_LENGTH} characters`,

--- a/apps/production/src/analytics/utils/transformers.ts
+++ b/apps/production/src/analytics/utils/transformers.ts
@@ -1,0 +1,182 @@
+import * as _round from 'lodash/round'
+import * as _isEmpty from 'lodash/isEmpty'
+import * as _keys from 'lodash/keys'
+import * as _values from 'lodash/values'
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
+
+const processMetaKV = (
+  rawMeta: Record<string, string>,
+): { 'meta.key': string | null; 'meta.value': string | null } => {
+  if (!rawMeta || _isEmpty(rawMeta)) {
+    return {
+      'meta.key': null,
+      'meta.value': null,
+    }
+  }
+
+  return {
+    'meta.key': _keys(rawMeta),
+    'meta.value': _values(rawMeta),
+  }
+}
+
+export const trafficTransformer = (
+  psid: string,
+  sid: string,
+  pid: string,
+  pg: string | null,
+  prev: string | null,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  lc: string | null,
+  ref: string | null,
+  so: string | null,
+  me: string | null,
+  ca: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  meta: Record<string, string> | null,
+  sdur: number,
+  unique: number,
+) => {
+  return {
+    psid,
+    sid,
+    pid,
+    pg: pg || null,
+    prev: prev || null,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    lc: lc || null,
+    ref: ref || null,
+    so: so || null,
+    me: me || null,
+    ca: ca || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    ...processMetaKV(meta),
+    sdur,
+    unique,
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}
+
+export const customEventTransformer = (
+  psid: string,
+  pid: string,
+  ev: string,
+  pg: string | null,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  lc: string | null,
+  ref: string | null,
+  so: string | null,
+  me: string | null,
+  ca: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  meta: Record<string, string> | null,
+) => {
+  return {
+    psid,
+    pid,
+    ev,
+    pg: pg || null,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    lc: lc || null,
+    ref: ref || null,
+    so: so || null,
+    me: me || null,
+    ca: ca || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    ...processMetaKV(meta),
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}
+
+export const errorEventTransformer = (
+  eid: string,
+  pid: string,
+  pg: string | null,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  lc: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  name: string | null,
+  message: string | null,
+  lineno: number | null,
+  colno: number | null,
+  filename: string | null,
+) => {
+  return {
+    eid,
+    pid,
+    pg: pg || null,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    lc: lc || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    name: name || null,
+    message: message || null,
+    lineno: lineno || null,
+    colno: colno || null,
+    filename: filename || null,
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}
+
+export const performanceTransformer = (
+  pid: string,
+  pg: string | null,
+  dv: string | null,
+  br: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  dns: number,
+  tls: number,
+  conn: number,
+  response: number,
+  render: number,
+  domLoad: number,
+  pageLoad: number,
+  ttfb: number,
+) => {
+  return {
+    pid,
+    pg: pg || null,
+    dv: dv || null,
+    br: br || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    dns: _round(dns),
+    tls: _round(tls),
+    conn: _round(conn),
+    response: _round(response),
+    render: _round(render),
+    domLoad: _round(domLoad),
+    pageLoad: _round(pageLoad),
+    ttfb: _round(ttfb),
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}

--- a/apps/production/src/app.controller.ts
+++ b/apps/production/src/app.controller.ts
@@ -1,4 +1,5 @@
-import { Get, Controller } from '@nestjs/common'
+import { Get, Controller, OnApplicationShutdown } from '@nestjs/common'
+import { clickhouse } from './common/integrations/clickhouse'
 
 const DEPLOYMENT_INFORMATION = {
   name: 'Swetrix API',
@@ -8,7 +9,11 @@ const DEPLOYMENT_INFORMATION = {
 }
 
 @Controller()
-export class AppController {
+export class AppController implements OnApplicationShutdown {
+  async onApplicationShutdown(): Promise<void> {
+    await clickhouse.close()
+  }
+
   @Get()
   root(): any {
     return DEPLOYMENT_INFORMATION

--- a/apps/production/src/captcha/captcha.controller.ts
+++ b/apps/production/src/captcha/captcha.controller.ts
@@ -89,13 +89,7 @@ export class CaptchaController {
 
     const ip = getIPFromHeaders(headers) || reqIP || ''
 
-    await this.captchaService.logCaptchaPass(
-      pid,
-      userAgent,
-      timestamp,
-      true,
-      ip,
-    )
+    await this.captchaService.logCaptchaPass(pid, userAgent, timestamp, ip)
 
     return {
       success: true,

--- a/apps/production/src/captcha/utils/transformers.ts
+++ b/apps/production/src/captcha/utils/transformers.ts
@@ -1,0 +1,23 @@
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
+
+export const captchaTransformer = (
+  pid: string,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  cc: string | null,
+  timestamp: number,
+) => {
+  return {
+    pid,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    cc: cc || null,
+    manuallyPassed: 1,
+    created: dayjs.utc(timestamp).format('YYYY-MM-DD HH:mm:ss'),
+  }
+}

--- a/apps/production/src/common/constants.ts
+++ b/apps/production/src/common/constants.ts
@@ -1,4 +1,3 @@
-import { ClickHouse } from 'clickhouse'
 import Redis from 'ioredis'
 import * as path from 'path'
 import { hash } from 'blake3'
@@ -7,12 +6,8 @@ import * as _toNumber from 'lodash/toNumber'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config()
 
-const {
-  CLICKHOUSE_DATABASE,
-  PAYPAL_CLIENT_ID,
-  PAYPAL_CLIENT_SECRET,
-  EMAIL_ACTION_ENCRYPTION_KEY,
-} = process.env
+const { PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET, EMAIL_ACTION_ENCRYPTION_KEY } =
+  process.env
 
 const redis = new Redis(
   _toNumber(process.env.REDIS_PORT),
@@ -27,26 +22,6 @@ const redis = new Redis(
 redis.defineCommand('countKeysByPattern', {
   numberOfKeys: 0,
   lua: "return #redis.call('keys', ARGV[1])",
-})
-
-const clickhouse = new ClickHouse({
-  url: process.env.CLICKHOUSE_HOST,
-  port: _toNumber(process.env.CLICKHOUSE_PORT),
-  debug: false,
-  basicAuth: {
-    username: process.env.CLICKHOUSE_USER,
-    password: process.env.CLICKHOUSE_PASSWORD,
-  },
-  isUseGzip: false,
-  format: 'json',
-  raw: false,
-  config: {
-    session_timeout: 60,
-    output_format_json_quote_64bit_integers: 0,
-    enable_http_compression: 0,
-    database: CLICKHOUSE_DATABASE,
-    log_queries: 0,
-  },
 })
 
 const {
@@ -193,7 +168,6 @@ const NUMBER_JWT_ACCESS_TOKEN_LIFETIME = Number(JWT_ACCESS_TOKEN_LIFETIME)
 const MAX_FUNNELS = 100
 
 export {
-  clickhouse,
   redis,
   isValidPID,
   getRedisProjectKey,

--- a/apps/production/src/common/constants.ts
+++ b/apps/production/src/common/constants.ts
@@ -50,11 +50,6 @@ const getRedisUserCountKey = (uid: string) => `user_c_${uid}`
 const getRedisUserUsageInfoKey = (uid: string) => `user_ui_${uid}`
 const getRedisCaptchaKey = (token: string) => `captcha_${hash(token)}`
 
-const REDIS_LOG_DATA_CACHE_KEY = 'log_cache'
-const REDIS_LOG_CAPTCHA_CACHE_KEY = 'log:captcha'
-const REDIS_LOG_PERF_CACHE_KEY = 'perf_cache'
-const REDIS_LOG_CUSTOM_CACHE_KEY = 'log_custom_cache_v3'
-const REDIS_LOG_ERROR_CACHE_KEY = 'log_error_cache'
 const REDIS_SESSION_SALT_KEY = 'log_salt' // is updated every 24 hours
 const REDIS_USERS_COUNT_KEY = 'stats:users_count'
 const REDIS_PROJECTS_COUNT_KEY = 'stats:projects_count'
@@ -173,12 +168,9 @@ export {
   getRedisProjectKey,
   redisProjectCacheTimeout,
   UNIQUE_SESSION_LIFE_TIME,
-  REDIS_LOG_DATA_CACHE_KEY,
-  REDIS_LOG_CAPTCHA_CACHE_KEY,
   GDPR_EXPORT_TIMEFRAME,
   getRedisUserCountKey,
   redisProjectCountCacheTimeout,
-  REDIS_LOG_CUSTOM_CACHE_KEY,
   REDIS_SESSION_SALT_KEY,
   HEARTBEAT_SID_LIFE_TIME,
   REDIS_USERS_COUNT_KEY,
@@ -189,7 +181,6 @@ export {
   TWO_FACTOR_AUTHENTICATION_APP_NAME,
   IP_REGEX,
   ORIGINS_REGEX,
-  REDIS_LOG_PERF_CACHE_KEY,
   CAPTCHA_SALT,
   EMAIL_ACTION_ENCRYPTION_KEY,
   isDevelopment,
@@ -220,6 +211,5 @@ export {
   BLOG_POSTS_ROOT,
   TRAFFIC_SPIKE_ALLOWED_PERCENTAGE,
   AFFILIATE_CUT,
-  REDIS_LOG_ERROR_CACHE_KEY,
   PID_REGEX,
 }

--- a/apps/production/src/common/integrations/clickhouse.ts
+++ b/apps/production/src/common/integrations/clickhouse.ts
@@ -1,4 +1,58 @@
-import { createClient } from '@clickhouse/client'
+import type {
+  Logger as _CHLogger,
+  LogParams,
+  ErrorLogParams,
+} from '@clickhouse/client'
+import { createClient, ClickHouseLogLevel } from '@clickhouse/client'
+import { Logger } from '@nestjs/common'
+
+export class CHLogger implements _CHLogger {
+  debug({ module, message, args }: LogParams): void {
+    Logger.debug({
+      type: '@clickhouse/client',
+      module,
+      message,
+      ...args,
+    })
+  }
+
+  trace({ module, message, args }: LogParams) {
+    Logger.log({
+      type: '@clickhouse/client',
+      module,
+      message,
+      ...args,
+    })
+  }
+
+  info({ module, message, args }: LogParams): void {
+    Logger.log({
+      type: '@clickhouse/client',
+      module,
+      message,
+      ...args,
+    })
+  }
+
+  warn({ module, message, args }: LogParams): void {
+    Logger.warn({
+      type: '@clickhouse/client',
+      module,
+      message,
+      ...args,
+    })
+  }
+
+  error({ module, message, args, err }: ErrorLogParams): void {
+    Logger.error({
+      type: '@clickhouse/client',
+      module,
+      message,
+      ...args,
+      err,
+    })
+  }
+}
 
 const clickhouse = createClient({
   url: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
@@ -15,6 +69,10 @@ const clickhouse = createClient({
     output_format_json_quote_64bit_integers: 0,
     enable_http_compression: 0,
     log_queries: 0,
+  },
+  log: {
+    LoggerClass: CHLogger,
+    level: ClickHouseLogLevel.INFO,
   },
 })
 

--- a/apps/production/src/common/integrations/clickhouse.ts
+++ b/apps/production/src/common/integrations/clickhouse.ts
@@ -69,6 +69,11 @@ const clickhouse = createClient({
     output_format_json_quote_64bit_integers: 0,
     enable_http_compression: 0,
     log_queries: 0,
+
+    // Used for analytics & captcha stuff.
+    // https://clickhouse.com/docs/en/optimize/asynchronous-inserts
+    wait_for_async_insert: 0, // Return ACK (await) when row was added to the buffer, not flushed to the database
+    async_insert_busy_timeout_ms: 15000, // 15 seconds; this is how long the buffer will be kept before writing stuff into the database
   },
   log: {
     LoggerClass: CHLogger,

--- a/apps/production/src/common/integrations/clickhouse.ts
+++ b/apps/production/src/common/integrations/clickhouse.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@clickhouse/client'
+
+const clickhouse = createClient({
+  host: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
+  username: process.env.CLICKHOUSE_USER,
+  password: process.env.CLICKHOUSE_PASSWORD,
+  database: process.env.CLICKHOUSE_DATABASE,
+  request_timeout: 60000, // 1 minute
+  clickhouse_settings: {
+    connect_timeout: 60000,
+    date_time_output_format: 'iso',
+    max_download_buffer_size: (10 * 1024 * 1024).toString(),
+    max_download_threads: 32,
+    max_execution_time: 60000,
+    output_format_json_quote_64bit_integers: 0,
+    enable_http_compression: 0,
+    log_queries: 0,
+  },
+})
+
+export { clickhouse }

--- a/apps/production/src/common/integrations/clickhouse.ts
+++ b/apps/production/src/common/integrations/clickhouse.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@clickhouse/client'
 
 const clickhouse = createClient({
-  host: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
+  url: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
   username: process.env.CLICKHOUSE_USER,
   password: process.env.CLICKHOUSE_PASSWORD,
   database: process.env.CLICKHOUSE_DATABASE,

--- a/apps/production/src/health/health-indicators/clickhouse.health-indicator.ts
+++ b/apps/production/src/health/health-indicators/clickhouse.health-indicator.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common'
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus'
+import { clickhouse } from '../../common/integrations/clickhouse'
+
+@Injectable()
+export class ClickhouseHealthIndicator extends HealthIndicator {
+  async pingCheck(key: string): Promise<HealthIndicatorResult> {
+    const ping = await clickhouse.ping()
+    const result = this.getStatus(key, ping.success)
+
+    // I'm doing "=== true" because otherwise Typescript complains that "ping.error" beneath if undefined
+    if (ping.success === true) return result
+
+    throw new HealthCheckError('Clickhouse check failed', ping.error)
+  }
+}

--- a/apps/production/src/health/health.controller.ts
+++ b/apps/production/src/health/health.controller.ts
@@ -1,40 +1,27 @@
 import { Controller, Get } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import {
   HealthCheckService,
   TypeOrmHealthIndicator,
-  HttpHealthIndicator,
   HealthCheck,
 } from '@nestjs/terminus'
 import { RedisHealthIndicator } from './health-indicators/redis.health-indicator'
+import { ClickhouseHealthIndicator } from './health-indicators/clickhouse.health-indicator'
 
 @Controller('health')
 export class HealthController {
   constructor(
-    private readonly configService: ConfigService,
     private readonly health: HealthCheckService,
     private readonly typeOrmHealthIndicator: TypeOrmHealthIndicator,
-    private readonly httpHealthIndicator: HttpHealthIndicator,
     private readonly redisHealthIndicator: RedisHealthIndicator,
+    private readonly clickhouseHealthIndicator: ClickhouseHealthIndicator,
   ) {}
 
   @Get()
   @HealthCheck()
   async check() {
-    const clickhouseHost = this.configService.get<string>('CLICKHOUSE_HOST')
-    const clickhousePort = Number(
-      this.configService.get<number>('CLICKHOUSE_PORT'),
-    )
-    const clickhousePingUrl = `${clickhouseHost}:${clickhousePort}/ping`
-
     return this.health.check([
       () => this.typeOrmHealthIndicator.pingCheck('database'),
-      () =>
-        this.httpHealthIndicator.responseCheck(
-          'analyticsDatabase',
-          clickhousePingUrl,
-          res => res.data === 'Ok.\n',
-        ),
+      () => this.clickhouseHealthIndicator.pingCheck('analyticsDatabase'),
       () => this.redisHealthIndicator.pingCheck('cache'),
     ])
   }

--- a/apps/production/src/health/health.module.ts
+++ b/apps/production/src/health/health.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common'
 import { TerminusModule } from '@nestjs/terminus'
 import { RedisHealthIndicator } from './health-indicators/redis.health-indicator'
+import { ClickhouseHealthIndicator } from './health-indicators/clickhouse.health-indicator'
 import { HealthController } from './health.controller'
 
 @Module({
   imports: [TerminusModule.forRoot({ logger: false })],
   controllers: [HealthController],
-  providers: [RedisHealthIndicator],
+  providers: [RedisHealthIndicator, ClickhouseHealthIndicator],
 })
 export class HealthModule {}

--- a/apps/production/src/main.ts
+++ b/apps/production/src/main.ts
@@ -67,6 +67,8 @@ async function bootstrap() {
     app.use(bot.webhookCallback(process.env.TELEGRAM_WEBHOOK_PATH))
   }
 
+  app.enableShutdownHooks()
+
   await app.listen(5005)
 }
 bootstrap()

--- a/apps/production/src/project/project.service.ts
+++ b/apps/production/src/project/project.service.ts
@@ -588,6 +588,10 @@ export class ProjectService {
       'ALTER TABLE customEV DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
     const queryPerformance =
       'ALTER TABLE performance DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
+    const queryErrors =
+      'ALTER TABLE errors DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
+    const queryErrorStatuses =
+      'ALTER TABLE error_statuses DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
     const params = {
       params: {
         pid,
@@ -607,6 +611,14 @@ export class ProjectService {
       }),
       clickhouse.query({
         query: queryPerformance,
+        query_params: params,
+      }),
+      clickhouse.query({
+        query: queryErrors,
+        query_params: params,
+      }),
+      clickhouse.query({
+        query: queryErrorStatuses,
         query_params: params,
       }),
     ])

--- a/apps/production/src/user/user.controller.ts
+++ b/apps/production/src/user/user.controller.ts
@@ -49,10 +49,10 @@ import {
 import { Pagination } from '../common/pagination/pagination'
 import {
   GDPR_EXPORT_TIMEFRAME,
-  clickhouse,
   isDevelopment,
   PRODUCTION_ORIGIN,
 } from '../common/constants'
+import { clickhouse } from '../common/integrations/clickhouse'
 import { RolesGuard } from '../auth/guards/roles.guard'
 import { UpdateUserProfileDTO } from './dto/update-user.dto'
 import { IChangePlanDTO } from './dto/change-plan.dto'
@@ -318,20 +318,26 @@ export class UserController {
           _map(user.projects, el => `'${el.id}'`),
           ',',
         )
-        const query1 = `ALTER table analytics DELETE WHERE pid IN (${pids})`
-        const query2 = `ALTER table customEV DELETE WHERE pid IN (${pids})`
-        const query3 = `ALTER table performance DELETE WHERE pid IN (${pids})`
-        const query4 = `ALTER table errors DELETE WHERE pid IN (${pids})`
-        const query5 = `ALTER table error_statuses DELETE WHERE pid IN (${pids})`
-        const query6 = `ALTER table captcha DELETE WHERE pid IN (${pids})`
+
+        const queries = [
+          `ALTER table analytics DELETE WHERE pid IN (${pids})`,
+          `ALTER table customEV DELETE WHERE pid IN (${pids})`,
+          `ALTER table performance DELETE WHERE pid IN (${pids})`,
+          `ALTER table errors DELETE WHERE pid IN (${pids})`,
+          `ALTER table error_statuses DELETE WHERE pid IN (${pids})`,
+          `ALTER table captcha DELETE WHERE pid IN (${pids})`,
+        ]
+
         await this.projectService.deleteMultiple(pids)
-        await clickhouse.query(query1).toPromise()
-        await clickhouse.query(query2).toPromise()
-        await clickhouse.query(query3).toPromise()
-        await clickhouse.query(query4).toPromise()
-        await clickhouse.query(query5).toPromise()
-        await clickhouse.query(query6).toPromise()
+
+        const promises = _map(queries, async query =>
+          clickhouse.query({
+            query,
+          }),
+        )
+        await Promise.all(promises)
       }
+      await this.actionTokensService.deleteMultiple(`userId="${id}"`)
       await this.userService.delete(id)
 
       return 'accountDeleted'
@@ -367,19 +373,21 @@ export class UserController {
           _map(user.projects, el => `'${el.id}'`),
           ',',
         )
-        const query1 = `ALTER table analytics DELETE WHERE pid IN (${pids})`
-        const query2 = `ALTER table customEV DELETE WHERE pid IN (${pids})`
-        const query3 = `ALTER table performance DELETE WHERE pid IN (${pids})`
-        const query4 = `ALTER table errors DELETE WHERE pid IN (${pids})`
-        const query5 = `ALTER table error_statuses DELETE WHERE pid IN (${pids})`
-        const query6 = `ALTER table captcha DELETE WHERE pid IN (${pids})`
+        const queries = [
+          `ALTER table analytics DELETE WHERE pid IN (${pids})`,
+          `ALTER table customEV DELETE WHERE pid IN (${pids})`,
+          `ALTER table performance DELETE WHERE pid IN (${pids})`,
+          `ALTER table errors DELETE WHERE pid IN (${pids})`,
+          `ALTER table error_statuses DELETE WHERE pid IN (${pids})`,
+          `ALTER table captcha DELETE WHERE pid IN (${pids})`,
+        ]
         await this.projectService.deleteMultiple(pids)
-        await clickhouse.query(query1).toPromise()
-        await clickhouse.query(query2).toPromise()
-        await clickhouse.query(query3).toPromise()
-        await clickhouse.query(query4).toPromise()
-        await clickhouse.query(query5).toPromise()
-        await clickhouse.query(query6).toPromise()
+        const promises = _map(queries, async query =>
+          clickhouse.query({
+            query,
+          }),
+        )
+        await Promise.all(promises)
       }
       await this.actionTokensService.deleteMultiple(`userId="${id}"`)
       await this.userService.delete(id)

--- a/apps/selfhosted/src/analytics/analytics.controller.ts
+++ b/apps/selfhosted/src/analytics/analytics.controller.ts
@@ -3,10 +3,7 @@ import * as _isArray from 'lodash/isArray'
 import * as _pick from 'lodash/pick'
 import * as _map from 'lodash/map'
 import * as _uniqBy from 'lodash/uniqBy'
-import * as _round from 'lodash/round'
 import * as _includes from 'lodash/includes'
-import * as _keys from 'lodash/keys'
-import * as _values from 'lodash/values'
 import * as dayjs from 'dayjs'
 import * as utc from 'dayjs/plugin/utc'
 import * as dayjsTimezone from 'dayjs/plugin/timezone'
@@ -54,13 +51,9 @@ import { GetUserFlowDTO } from './dto/getUserFlow.dto'
 import { GetFunnelsDTO } from './dto/getFunnels.dto'
 import { AppLoggerService } from '../logger/logger.service'
 import {
-  REDIS_LOG_DATA_CACHE_KEY,
-  REDIS_LOG_PERF_CACHE_KEY,
   redis,
-  REDIS_LOG_CUSTOM_CACHE_KEY,
   HEARTBEAT_SID_LIFE_TIME,
   REDIS_SESSION_SALT_KEY,
-  REDIS_LOG_ERROR_CACHE_KEY,
 } from '../common/constants'
 import { clickhouse } from '../common/integrations/clickhouse'
 import {
@@ -84,9 +77,12 @@ import { ErrorDTO } from './dto/error.dto'
 import { GetErrorsDto } from './dto/get-errors.dto'
 import { GetErrorDTO } from './dto/get-error.dto'
 import { PatchStatusDTO } from './dto/patch-status.dto'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const mysql = require('mysql2')
+import {
+  customEventTransformer,
+  errorEventTransformer,
+  performanceTransformer,
+  trafficTransformer,
+} from './utils/transformers'
 
 dayjs.extend(utc)
 dayjs.extend(dayjsTimezone)
@@ -100,177 +96,6 @@ const getSessionKeyCustom = (
   ev: string,
   salt = '',
 ) => `cses_${hash(`${ua}${ip}${pid}${ev}${salt}`).toString('hex')}`
-
-const analyticsDTO = (
-  psid: string,
-  sid: string,
-  pid: string,
-  pg: string,
-  prev: string,
-  dv: string,
-  br: string,
-  os: string,
-  lc: string,
-  ref: string,
-  so: string,
-  me: string,
-  ca: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  keys: string[],
-  values: string[],
-  sdur: number | string,
-  unique: number,
-): Array<string | number | string[]> => {
-  return [
-    psid,
-    sid,
-    pid,
-    pg,
-    prev,
-    dv,
-    br,
-    os,
-    lc,
-    ref,
-    so,
-    me,
-    ca,
-    cc,
-    rg,
-    ct,
-    keys,
-    values,
-    sdur,
-    unique,
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const performanceDTO = (
-  pid: string,
-  pg: string,
-  dv: string,
-  br: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  dns: number,
-  tls: number,
-  conn: number,
-  response: number,
-  render: number,
-  domLoad: number,
-  pageLoad: number,
-  ttfb: number,
-): Array<string | number> => {
-  return [
-    pid,
-    pg,
-    dv,
-    br,
-    cc,
-    rg,
-    ct,
-    _round(dns),
-    _round(tls),
-    _round(conn),
-    _round(response),
-    _round(render),
-    _round(domLoad),
-    _round(pageLoad),
-    _round(ttfb),
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const customLogDTO = (
-  psid: string,
-  pid: string,
-  ev: string,
-  pg: string,
-  dv: string,
-  br: string,
-  os: string,
-  lc: string,
-  ref: string,
-  so: string,
-  me: string,
-  ca: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  keys: string[],
-  values: string[],
-): Array<string | number | string[]> => {
-  return [
-    psid,
-    pid,
-    ev,
-    pg,
-    dv,
-    br,
-    os,
-    lc,
-    ref,
-    so,
-    me,
-    ca,
-    cc,
-    rg,
-    ct,
-    keys,
-    values,
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const errorLogDTO = (
-  eid: string,
-  pid: string,
-  pg: string,
-  dv: string,
-  br: string,
-  os: string,
-  lc: string,
-  cc: string,
-  rg: string,
-  ct: string,
-  name: string,
-  message: string,
-  lineno: number,
-  colno: number,
-  filename: string,
-): Array<string | number | string[]> => {
-  return [
-    eid,
-    pid,
-    pg,
-    dv,
-    br,
-    os,
-    lc,
-    cc,
-    rg,
-    ct,
-    name,
-    message,
-    lineno,
-    colno,
-    filename,
-    dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
-  ]
-}
-
-const getElValue = el => {
-  if (_isArray(el)) {
-    return `[${_map(el, getElValue).join(',')}]`
-  }
-
-  if (el === undefined || el === null || el === 'NULL') return 'NULL'
-  return mysql.escape(el)
-}
 
 // Performance object validator: none of the values cannot be bigger than 1000 * 60 * 5 (5 minutes) and are >= 0
 const MAX_PERFORMANCE_VALUE = 1000 * 60 * 5
@@ -1117,7 +942,7 @@ export class AnalyticsController {
     const sessionHash = getSessionKey(ip, userAgent, eventsDTO.pid, salt)
     const [, psid] = await this.analyticsService.isUnique(sessionHash)
 
-    const dto = customLogDTO(
+    const transformed = customEventTransformer(
       psid,
       eventsDTO.pid,
       eventsDTO.ev,
@@ -1133,13 +958,18 @@ export class AnalyticsController {
       country,
       region,
       city,
-      _keys(eventsDTO.meta),
-      _values(eventsDTO.meta),
+      eventsDTO.meta,
     )
 
     try {
-      const values = `(${dto.map(getElValue).join(',')})`
-      await redis.rpush(REDIS_LOG_CUSTOM_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'customEV',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
     } catch (e) {
       this.logger.error(e)
       throw new InternalServerErrorException(
@@ -1215,7 +1045,7 @@ export class AnalyticsController {
     const br = ua.browser.name
     const os = ua.os.name
 
-    const dto = analyticsDTO(
+    const transformed = trafficTransformer(
       psid,
       sessionHash,
       logDTO.pid,
@@ -1232,13 +1062,12 @@ export class AnalyticsController {
       country,
       region,
       city,
-      _keys(logDTO.meta),
-      _values(logDTO.meta),
+      logDTO.meta,
       0,
       Number(unique),
     )
 
-    let perfDTO: Array<string | number> = []
+    let perfTransformed = null
 
     if (!_isEmpty(logDTO.perf) && isPerformanceValid(logDTO.perf)) {
       const {
@@ -1252,7 +1081,7 @@ export class AnalyticsController {
         ttfb,
       } = logDTO.perf
 
-      perfDTO = performanceDTO(
+      perfTransformed = performanceTransformer(
         logDTO.pid,
         logDTO.pg,
         dv,
@@ -1271,13 +1100,25 @@ export class AnalyticsController {
       )
     }
 
-    const values = `(${dto.map(getElValue).join(',')})`
     try {
-      await redis.rpush(REDIS_LOG_DATA_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'analytics',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
 
-      if (!_isEmpty(perfDTO)) {
-        const perfValues = `(${perfDTO.map(getElValue).join(',')})`
-        await redis.rpush(REDIS_LOG_PERF_CACHE_KEY, perfValues)
+      if (!_isEmpty(perfTransformed)) {
+        await clickhouse.insert({
+          table: 'performance',
+          format: 'JSONEachRow',
+          values: [perfTransformed],
+          clickhouse_settings: {
+            async_insert: 1,
+          },
+        })
       }
     } catch (e) {
       this.logger.error(e)
@@ -1330,32 +1171,37 @@ export class AnalyticsController {
       country = 'NULL',
     } = getGeoDetails(ip, null, headers)
 
-    const dto = analyticsDTO(
+    const transformed = trafficTransformer(
       psid,
       sessionHash,
       logDTO.pid,
-      'NULL',
-      'NULL',
+      null,
+      null,
       dv,
       br,
       os,
-      'NULL',
-      'NULL',
-      'NULL',
-      'NULL',
-      'NULL',
-      city,
-      region,
+      null,
+      null,
+      null,
+      null,
+      null,
       country,
-      [],
-      [],
+      region,
+      city,
+      null,
       0,
       Number(unique),
     )
 
-    const values = `(${dto.map(getElValue).join(',')})`
     try {
-      await redis.rpush(REDIS_LOG_DATA_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'analytics',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
     } catch (e) {
       this.logger.error(e)
     }
@@ -1635,7 +1481,7 @@ export class AnalyticsController {
 
     const { name, message, lineno, colno, filename } = errorDTO
 
-    const dto = errorLogDTO(
+    const transformed = errorEventTransformer(
       this.analyticsService.getErrorID(errorDTO),
       errorDTO.pid,
       errorDTO.pg,
@@ -1654,8 +1500,14 @@ export class AnalyticsController {
     )
 
     try {
-      const values = `(${dto.map(getElValue).join(',')})`
-      await redis.rpush(REDIS_LOG_ERROR_CACHE_KEY, values)
+      await clickhouse.insert({
+        table: 'errors',
+        format: 'JSONEachRow',
+        values: [transformed],
+        clickhouse_settings: {
+          async_insert: 1,
+        },
+      })
     } catch (e) {
       this.logger.error(e)
       throw new InternalServerErrorException(

--- a/apps/selfhosted/src/analytics/analytics.service.ts
+++ b/apps/selfhosted/src/analytics/analytics.service.ts
@@ -42,7 +42,6 @@ import {
   redis,
   isValidPID,
   UNIQUE_SESSION_LIFE_TIME,
-  clickhouse,
   REDIS_SESSION_SALT_KEY,
   TRAFFIC_COLUMNS,
   PERFORMANCE_COLUMNS,
@@ -52,6 +51,7 @@ import {
   ALL_COLUMNS,
   TRAFFIC_METAKEY_COLUMNS,
 } from '../common/constants'
+import { clickhouse } from '../common/integrations/clickhouse'
 import {
   getFunnelsClickhouse,
   millisecondsToSeconds,
@@ -471,11 +471,16 @@ export class AnalyticsService {
 
     const query = `SELECT ${type} FROM errors WHERE pid={pid:FixedString(12)} AND ${type} IS NOT NULL GROUP BY ${type}`
 
-    const results = await clickhouse
-      .query(query, { params: { pid } })
-      .toPromise()
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: {
+          pid,
+        },
+      })
+      .then(resultSet => resultSet.json())
 
-    return _map(results, type)
+    return _map(data, type)
   }
 
   getDataTypeColumns(dataType: DataType): string[] {
@@ -633,7 +638,10 @@ export class AnalyticsService {
     return { nodes, links }
   }
 
-  async getUserFlow(params: unknown, filtersQuery: string): Promise<IUserFlow> {
+  async getUserFlow(
+    params: Record<string, unknown>,
+    filtersQuery: string,
+  ): Promise<IUserFlow> {
     const query = `
       SELECT
         pg AS source,
@@ -650,11 +658,14 @@ export class AnalyticsService {
         prev
     `
 
-    const results = <IUserFlowLink[]>(
-      await clickhouse.query(query, { params }).toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: params,
+      })
+      .then(resultSet => resultSet.json<IUserFlowLink>())
 
-    if (_isEmpty(results)) {
+    if (_isEmpty(data)) {
       const empty = { nodes: [], links: [] }
       return {
         ascending: empty,
@@ -665,7 +676,7 @@ export class AnalyticsService {
     const ascendingLinks: IUserFlowLink[] = []
     const descendingLinks: IUserFlowLink[] = []
 
-    this.removeCyclicDependencies(results).forEach((row: any) => {
+    this.removeCyclicDependencies(data).forEach((row: any) => {
       const link: IUserFlowLink = {
         source: row.source,
         target: row.target,
@@ -790,12 +801,14 @@ export class AnalyticsService {
       return null
     }
 
-    const from: any = await clickhouse
-      .query(
-        'SELECT created FROM analytics where pid = {pid:FixedString(12)} ORDER BY created ASC LIMIT 1',
-        { params: { pid } },
-      )
-      .toPromise()
+    const { data: from } = await clickhouse
+      .query({
+        query:
+          'SELECT created FROM analytics WHERE pid = {pid:FixedString(12)} ORDER BY created ASC LIMIT 1',
+        query_params: { pid },
+      })
+      .then(res => res.json<{ created?: string }>())
+
     const to = _includes(GMT_0_TIMEZONES, safeTimezone)
       ? dayjs.utc()
       : dayjs().tz(safeTimezone)
@@ -1169,20 +1182,18 @@ export class AnalyticsService {
       ORDER BY level DESC;
     `
 
-    const result = <Array<IFunnelCHResponse>>(
-      await clickhouse
-        .query(query, { params: { ...params, ...pageParams } })
-        .toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: { ...params, ...pageParams },
+      })
+      .then(resultSet => resultSet.json<IFunnelCHResponse>())
 
-    if (_isEmpty(result)) {
+    if (_isEmpty(data)) {
       return this.generateEmptyFunnel(pages)
     }
 
-    return this.formatFunnel(
-      _reverse(this.backfillFunnel(result, pages)),
-      pages,
-    )
+    return this.formatFunnel(_reverse(this.backfillFunnel(data, pages)), pages)
   }
 
   async getTotalPageviews(
@@ -1197,13 +1208,14 @@ export class AnalyticsService {
       WHERE pid = {pid:FixedString(12)}
       AND created BETWEEN {groupFrom:String} AND {groupTo:String}
     `
-    const result = <{ c: number }[]>(
-      await clickhouse
-        .query(query, { params: { pid, groupFrom, groupTo } })
-        .toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: { pid, groupFrom, groupTo },
+      })
+      .then(resultSet => resultSet.json<{ c: number }>())
 
-    return result[0]?.c || 0
+    return data[0]?.c || 0
   }
 
   async getAnalyticsSummary(
@@ -1256,27 +1268,28 @@ export class AnalyticsService {
             queryAll = `SELECT count(*) AS all FROM customEV WHERE pid = {pid:FixedString(12)} ${filtersQuery}`
           }
 
-          const rawResult = <Array<BirdseyeCHResponse>>await clickhouse
-            .query(queryAll, {
-              params: { pid, ...filtersParams },
+          const { data } = await clickhouse
+            .query({
+              query: queryAll,
+              query_params: {
+                pid,
+                ...filtersParams,
+              },
             })
-            .toPromise()
+            .then(resultSet => resultSet.json<BirdseyeCHResponse>())
 
           let bounceRate = 0
 
-          if (rawResult[0].all > 0 && !customEVFilterApplied) {
-            bounceRate = _round(
-              (rawResult[0].unique * 100) / rawResult[0].all,
-              1,
-            )
+          if (data[0].all > 0 && !customEVFilterApplied) {
+            bounceRate = _round((data[0].unique * 100) / data[0].all, 1)
           }
 
           result[pid] = {
             current: {
-              all: rawResult[0].all,
-              unique: rawResult[0].unique,
+              all: data[0].all,
+              unique: data[0].unique,
               bounceRate,
-              sdur: rawResult[0].sdur,
+              sdur: data[0].sdur,
             },
             previous: {
               all: 0,
@@ -1284,10 +1297,10 @@ export class AnalyticsService {
               bounceRate: 0,
               sdur: 0,
             },
-            change: rawResult[0].all,
-            uniqueChange: rawResult[0].unique,
+            change: data[0].all,
+            uniqueChange: data[0].unique,
             bounceRateChange: bounceRate,
-            sdurChange: rawResult[0].sdur,
+            sdurChange: data[0].sdur,
             customEVFilterApplied,
           }
           return
@@ -1328,9 +1341,10 @@ export class AnalyticsService {
 
         const query = `${queryCurrent} UNION ALL ${queryPrevious}`
 
-        let rawResult = <Array<BirdseyeCHResponse>>await clickhouse
-          .query(query, {
-            params: {
+        let { data } = await clickhouse
+          .query({
+            query,
+            query_params: {
               pid,
               periodFormatted,
               periodSubtracted,
@@ -1338,12 +1352,12 @@ export class AnalyticsService {
               ...filtersParams,
             },
           })
-          .toPromise()
+          .then(resultSet => resultSet.json<BirdseyeCHResponse>())
 
-        rawResult = _sortBy(rawResult, 'sortOrder')
+        data = _sortBy(data, 'sortOrder')
 
-        const currentPeriod = rawResult[0]
-        const previousPeriod = rawResult[1]
+        const currentPeriod = data[0]
+        const previousPeriod = data[1]
 
         let bounceRate = 0
         let prevBounceRate = 0
@@ -1452,26 +1466,23 @@ export class AnalyticsService {
       try {
         if (period === 'all') {
           const queryAll = `SELECT ${columnSelectors} FROM performance WHERE pid = {pid:FixedString(12)} ${filtersQuery}`
-          const rawResult = <Array<Partial<PerformanceCHResponse>>>(
-            await clickhouse
-              .query(queryAll, {
-                params: { pid, ...filtersParams },
-              })
-              .toPromise()
-          )
+          const { data } = await clickhouse
+            .query({
+              query: queryAll,
+              query_params: {
+                pid,
+                ...filtersParams,
+              },
+            })
+            .then(resultSet => resultSet.json<Partial<PerformanceCHResponse>>())
 
           result[pid] = {
             current: {
-              frontend: millisecondsToSeconds(
-                rawResult[0].render + rawResult[0].domLoad,
-              ),
+              frontend: millisecondsToSeconds(data[0].render + data[0].domLoad),
               network: millisecondsToSeconds(
-                rawResult[0].dns +
-                  rawResult[0].tls +
-                  rawResult[0].conn +
-                  rawResult[0].response,
+                data[0].dns + data[0].tls + data[0].conn + data[0].response,
               ),
-              backend: millisecondsToSeconds(rawResult[0].ttfb),
+              backend: millisecondsToSeconds(data[0].ttfb),
             },
             previous: {
               frontend: 0,
@@ -1479,15 +1490,12 @@ export class AnalyticsService {
               backend: 0,
             },
             frontendChange: millisecondsToSeconds(
-              rawResult[0].render + rawResult[0].domLoad,
+              data[0].render + data[0].domLoad,
             ),
             networkChange: millisecondsToSeconds(
-              rawResult[0].dns +
-                rawResult[0].tls +
-                rawResult[0].conn +
-                rawResult[0].response,
+              data[0].dns + data[0].tls + data[0].conn + data[0].response,
             ),
-            backendChange: millisecondsToSeconds(rawResult[0].ttfb),
+            backendChange: millisecondsToSeconds(data[0].ttfb),
           }
           return
         }
@@ -1522,9 +1530,10 @@ export class AnalyticsService {
 
         const query = `${queryCurrent} UNION ALL ${queryPrevious}`
 
-        let rawResult = <Array<Partial<PerformanceCHResponse>>>await clickhouse
-          .query(query, {
-            params: {
+        let { data } = await clickhouse
+          .query({
+            query,
+            query_params: {
               pid,
               periodFormatted,
               periodSubtracted,
@@ -1532,12 +1541,12 @@ export class AnalyticsService {
               ...filtersParams,
             },
           })
-          .toPromise()
+          .then(resultSet => resultSet.json<Partial<PerformanceCHResponse>>())
 
-        rawResult = _sortBy(rawResult, 'sortOrder')
+        data = _sortBy(data, 'sortOrder')
 
-        const currentPeriod = rawResult[0]
-        const previousPeriod = rawResult[1]
+        const currentPeriod = data[0]
+        const previousPeriod = data[1]
 
         result[pid] = {
           current: {
@@ -1614,11 +1623,16 @@ export class AnalyticsService {
         'SELECT ev FROM customEV WHERE pid={pid:FixedString(12)} AND ev IS NOT NULL GROUP BY ev'
     }
 
-    const results = await clickhouse
-      .query(query, { params: { pid } })
-      .toPromise()
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: {
+          pid,
+        },
+      })
+      .then(resultSet => resultSet.json())
 
-    return _map(results, type)
+    return _map(data, type)
   }
 
   async generateParams(
@@ -1661,26 +1675,19 @@ export class AnalyticsService {
         type,
         measure,
       )
-      const res = await clickhouse.query(query, paramsData).toPromise()
+      const { data } = await clickhouse
+        .query({
+          query,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json())
 
-      params[col] = res
+      params[col] = data
     })
 
     await Promise.all(paramsPromises)
 
     return params
-  }
-
-  async calculateAverageSessionDuration(
-    subQuery: string,
-    paramsData: any,
-  ): Promise<number> {
-    const avgSdurQuery = `SELECT avg(sdur) ${subQuery} AND sdur IS NOT NULL AND unique='1'`
-    const avgSdurObject = await clickhouse
-      .query(avgSdurQuery, paramsData)
-      .toPromise()
-
-    return _round(avgSdurObject[0]['avg(sdur)'])
   }
 
   generateXAxis(
@@ -2217,13 +2224,15 @@ export class AnalyticsService {
         mode,
       )
 
-      const result = <Array<TrafficCEFilterCHResponse>>(
-        await clickhouse.query(query, paramsData).toPromise()
-      )
+      const { data } = await clickhouse
+        .query({
+          query,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json<TrafficCEFilterCHResponse>())
 
       const uniques =
-        this.extractCustomEventsChartData(result, xShifted)?._unknown_event ||
-        []
+        this.extractCustomEventsChartData(data, xShifted)?._unknown_event || []
 
       const sdur = Array(_size(xShifted)).fill(0)
 
@@ -2244,11 +2253,14 @@ export class AnalyticsService {
       mode,
     )
 
-    const result = <Array<TrafficCHResponse>>(
-      await clickhouse.query(query, paramsData).toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json<TrafficCHResponse>())
 
-    const { visits, uniques, sdur } = this.extractChartData(result, xShifted)
+    const { visits, uniques, sdur } = this.extractChartData(data, xShifted)
 
     return Promise.resolve({
       chart: {
@@ -2352,9 +2364,12 @@ export class AnalyticsService {
     //     ChartRenderMode.PERIODICAL,
     //   )
 
-    //   const result = <Array<TrafficCEFilterCHResponse>>(
-    //     await clickhouse.query(query, paramsData).toPromise()
-    //   )
+    //   const { data } = await clickhouse
+    //     .query({
+    //       query,
+    //       query_params: paramsData.params,
+    //     })
+    //     .then(resultSet => resultSet.json<TrafficCEFilterCHResponse>())
 
     //   const uniques =
     //     this.extractCustomEventsChartData(result, xShifted)?._unknown_event ||
@@ -2374,11 +2389,14 @@ export class AnalyticsService {
 
     const query = this.generateSessionAggregationQuery(timeBucket, filtersQuery)
 
-    const result = <Array<TrafficCHResponse>>(
-      await clickhouse.query(query, paramsData).toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json<TrafficCHResponse>())
 
-    const { visits, uniques, sdur } = this.extractChartData(result, x)
+    const { visits, uniques, sdur } = this.extractChartData(data, x)
 
     return Promise.resolve({
       chart: {
@@ -2396,7 +2414,7 @@ export class AnalyticsService {
     to: string,
     subQuery: string,
     filtersQuery: string,
-    paramsData: object,
+    paramsData: any,
     safeTimezone: string,
     mode: ChartRenderMode,
   ): Promise<object | void> {
@@ -2431,10 +2449,13 @@ export class AnalyticsService {
           mode,
         )
 
-        const result = <Array<TrafficCEFilterCHResponse>>(
-          await clickhouse.query(query, paramsData).toPromise()
-        )
-        const { count } = this.extractErrorsChartData(result, x)
+        const { data } = await clickhouse
+          .query({
+            query,
+            query_params: paramsData.params,
+          })
+          .then(resultSet => resultSet.json<TrafficCEFilterCHResponse>())
+        const { count } = this.extractErrorsChartData(data, x)
 
         chart = {
           x: this.shiftToTimezone(x, safeTimezone, format),
@@ -2492,7 +2513,7 @@ export class AnalyticsService {
     from: string,
     to: string,
     filtersQuery: string,
-    paramsData: object,
+    paramsData: any,
     safeTimezone: string,
     measure: PerfMeasure,
   ) {
@@ -2505,11 +2526,16 @@ export class AnalyticsService {
         safeTimezone,
       )
 
-      const result = await clickhouse.query(query, paramsData).toPromise()
+      const { data } = await clickhouse
+        .query({
+          query,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json())
 
       return {
         x: xShifted,
-        ...this.extractPerformanceQuantilesData(result, xShifted),
+        ...this.extractPerformanceQuantilesData(data, xShifted),
       }
     }
 
@@ -2520,13 +2546,16 @@ export class AnalyticsService {
       measure,
     )
 
-    const result = <Array<PerformanceCHResponse>>(
-      await clickhouse.query(query, paramsData).toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json<PerformanceCHResponse>())
 
     return {
       x: xShifted,
-      ...this.extractPerformanceChartData(result, xShifted),
+      ...this.extractPerformanceChartData(data, xShifted),
     }
   }
 
@@ -2536,7 +2565,7 @@ export class AnalyticsService {
     to: string,
     subQuery: string,
     filtersQuery: string,
-    paramsData: object,
+    paramsData: any,
     safeTimezone: string,
     measure: PerfMeasure,
   ): Promise<object | void> {
@@ -2586,18 +2615,21 @@ export class AnalyticsService {
 
   async getCustomEvents(
     filtersQuery: string,
-    params: object,
+    params: any,
   ): Promise<ICustomEvent> {
     const query = `SELECT ev, count() FROM customEV WHERE pid = {pid:FixedString(12)} ${filtersQuery} AND created BETWEEN {groupFrom:String} AND {groupTo:String} GROUP BY ev`
     const result = {}
 
-    const rawCustoms = <Array<CustomsCHResponse>>(
-      await clickhouse.query(query, params).toPromise()
-    )
-    const size = _size(rawCustoms)
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: params.params,
+      })
+      .then(resultSet => resultSet.json<CustomsCHResponse>())
+    const size = _size(data)
 
     for (let i = 0; i < size; ++i) {
-      const { ev, 'count()': c } = rawCustoms[i]
+      const { ev, 'count()': c } = data[i]
       result[ev] = c
     }
 
@@ -2618,7 +2650,7 @@ export class AnalyticsService {
 
   async getPageProperties(
     filtersQuery: string,
-    params: object,
+    params: any,
   ): Promise<IPageProperty> {
     const query = `
       SELECT
@@ -2631,13 +2663,16 @@ export class AnalyticsService {
       GROUP BY property`
     const result = {}
 
-    const rawProperties = <Array<PropertiesCHResponse>>(
-      await clickhouse.query(query, params).toPromise()
-    )
-    const size = _size(rawProperties)
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: params.params,
+      })
+      .then(resultSet => resultSet.json<PropertiesCHResponse>())
+    const size = _size(data)
 
     for (let i = 0; i < size; ++i) {
-      const { property: propertyArr, 'count()': c } = rawProperties[i]
+      const { property: propertyArr, 'count()': c } = data[i]
       const [property] = propertyArr
 
       if (!property) {
@@ -2728,9 +2763,12 @@ export class AnalyticsService {
     }
 
     try {
-      const result = (await clickhouse
-        .query(query, paramsData)
-        .toPromise()) as IAggregatedMetadata[]
+      const { data: result } = await clickhouse
+        .query({
+          query,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json<IAggregatedMetadata>())
 
       return {
         result,
@@ -2829,9 +2867,12 @@ export class AnalyticsService {
     }
 
     try {
-      const result = (await clickhouse
-        .query(query, paramsData)
-        .toPromise()) as IAggregatedMetadata[]
+      const { data: result } = await clickhouse
+        .query({
+          query,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json<IAggregatedMetadata>())
 
       return {
         result,
@@ -2855,7 +2896,7 @@ export class AnalyticsService {
     from: string,
     to: string,
     filtersQuery: string,
-    paramsData: object,
+    paramsData: any,
     safeTimezone: string,
   ): Promise<object | void> {
     const { xShifted } = this.generateXAxis(timeBucket, from, to, safeTimezone)
@@ -2883,11 +2924,14 @@ export class AnalyticsService {
       ORDER BY ${groupBy}
       `
 
-    const result = <Array<CustomsCHAggregatedResponse>>(
-      await clickhouse.query(query, paramsData).toPromise()
-    )
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json<CustomsCHAggregatedResponse>())
 
-    const events = this.extractCustomEventsChartData(result, xShifted)
+    const events = this.extractCustomEventsChartData(data, xShifted)
 
     return Promise.resolve({
       chart: {
@@ -2961,11 +3005,21 @@ export class AnalyticsService {
       },
     }
 
-    const pages = <IPageflow[]>(
-      await clickhouse.query(queryPages, paramsData).toPromise()
-    )
+    const { data: pages } = await clickhouse
+      .query({
+        query: queryPages,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json<IPageflow>())
+
     let details = (
-      await clickhouse.query(querySessionDetails, paramsData).toPromise()
+      await clickhouse
+        .query({
+          query: querySessionDetails,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json())
+        .then(({ data }) => data)
     )[0]
 
     if (!details) {
@@ -2982,8 +3036,12 @@ export class AnalyticsService {
       // eslint-disable-next-line prefer-destructuring
       details = (
         await clickhouse
-          .query(querySessionDetailsBackup, paramsData)
-          .toPromise()
+          .query({
+            query: querySessionDetailsBackup,
+            query_params: paramsData.params,
+          })
+          .then(resultSet => resultSet.json())
+          .then(({ data }) => data)
       )[0]
     }
 
@@ -3032,7 +3090,7 @@ export class AnalyticsService {
 
   async getSessionsList(
     filtersQuery: string,
-    paramsData: object,
+    paramsData: any,
     safeTimezone: string,
     take = 30,
     skip = 0,
@@ -3089,15 +3147,20 @@ export class AnalyticsService {
       OFFSET ${skip}
     `
 
-    const result = await clickhouse.query(query, paramsData).toPromise()
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json())
 
-    return result
+    return data
   }
 
   async getErrorsList(
     options: string,
     filtersQuery: string,
-    paramsData: object,
+    paramsData: any,
     safeTimezone: string,
     take = 30,
     skip = 0,
@@ -3147,9 +3210,14 @@ export class AnalyticsService {
       OFFSET ${skip};
     `
 
-    const result = await clickhouse.query(query, paramsData).toPromise()
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: paramsData.params,
+      })
+      .then(resultSet => resultSet.json())
 
-    return result
+    return data
   }
 
   async getErrorDetails(
@@ -3215,11 +3283,23 @@ export class AnalyticsService {
     }
 
     const details = (
-      await clickhouse.query(queryErrorDetails, paramsData).toPromise()
+      await clickhouse
+        .query({
+          query: queryErrorDetails,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json<any>())
+        .then(({ data }) => data)
     )[0]
 
     const occurenceDetails = (
-      await clickhouse.query(queryFirstLastSeen, paramsData).toPromise()
+      await clickhouse
+        .query({
+          query: queryFirstLastSeen,
+          query_params: paramsData.params,
+        })
+        .then(resultSet => resultSet.json<any>())
+        .then(({ data }) => data)
     )[0]
 
     const groupedChart = await this.groupErrorsByTimeBucket(
@@ -3269,9 +3349,16 @@ export class AnalyticsService {
     let result
 
     try {
-      ;[result] = await clickhouse
-        .query(query, { params: { ...params, pid } })
-        .toPromise()
+      // eslint-disable-next-line prefer-destructuring
+      result = (
+        await clickhouse
+          .query({
+            query,
+            query_params: { ...params, pid },
+          })
+          .then(resultSet => resultSet.json())
+          .then(({ data }) => data)
+      )[0]
     } catch (reason) {
       console.error('validateEIDs - clickhouse request error')
       console.error(reason)
@@ -3308,7 +3395,13 @@ export class AnalyticsService {
     ).join(', ')}`
 
     try {
-      await clickhouse.query(query, { params: { ...params, pid } }).toPromise()
+      await clickhouse.query({
+        query,
+        query_params: {
+          ...params,
+          pid,
+        },
+      })
     } catch (reason) {
       console.error('Error at PATCH error-status:')
       console.error(reason)

--- a/apps/selfhosted/src/analytics/dto/events.dto.ts
+++ b/apps/selfhosted/src/analytics/dto/events.dto.ts
@@ -1,5 +1,6 @@
 import * as _keys from 'lodash/keys'
 import * as _values from 'lodash/values'
+import * as _some from 'lodash/some'
 import { ApiProperty } from '@nestjs/swagger'
 import {
   IsNotEmpty,
@@ -37,6 +38,15 @@ export class MetadataKeysQuantity implements ValidatorConstraintInterface {
   }
 }
 
+@ValidatorConstraint()
+export class MetadataValueType implements ValidatorConstraintInterface {
+  validate(metadata: Record<string, string>) {
+    const values = _values(metadata)
+
+    return !_some(values, value => typeof value !== 'string')
+  }
+}
+
 export class EventsDTO {
   @ApiProperty({
     example: 'aUn1quEid-3',
@@ -58,7 +68,7 @@ export class EventsDTO {
     description:
       'If true, only 1 event with the same ID will be saved per user session',
   })
-  unique: object
+  unique: boolean
 
   // Tracking metrics
   @ApiProperty({
@@ -114,6 +124,9 @@ export class EventsDTO {
   @IsObject()
   @Validate(MetadataKeysQuantity, {
     message: `Metadata object can't have more than ${MAX_METADATA_KEYS} keys`,
+  })
+  @Validate(MetadataValueType, {
+    message: 'All of metadata object values must be strings',
   })
   @Validate(MetadataSizeLimit, {
     message: `Metadata object can't have values with total length more than ${MAX_METADATA_VALUE_LENGTH} characters`,

--- a/apps/selfhosted/src/analytics/dto/pageviews.dto.ts
+++ b/apps/selfhosted/src/analytics/dto/pageviews.dto.ts
@@ -5,6 +5,7 @@ import {
   MAX_METADATA_KEYS,
   MAX_METADATA_VALUE_LENGTH,
   MetadataKeysQuantity,
+  MetadataValueType,
   MetadataSizeLimit,
 } from './events.dto'
 
@@ -107,6 +108,9 @@ export class PageviewsDTO {
   @IsObject()
   @Validate(MetadataKeysQuantity, {
     message: `Metadata object can't have more than ${MAX_METADATA_KEYS} keys`,
+  })
+  @Validate(MetadataValueType, {
+    message: 'All of metadata object values must be strings',
   })
   @Validate(MetadataSizeLimit, {
     message: `Metadata object can't have values with total length more than ${MAX_METADATA_VALUE_LENGTH} characters`,

--- a/apps/selfhosted/src/analytics/utils/transformers.ts
+++ b/apps/selfhosted/src/analytics/utils/transformers.ts
@@ -1,0 +1,182 @@
+import * as _round from 'lodash/round'
+import * as _isEmpty from 'lodash/isEmpty'
+import * as _keys from 'lodash/keys'
+import * as _values from 'lodash/values'
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
+
+const processMetaKV = (
+  rawMeta: Record<string, string>,
+): { 'meta.key': string | null; 'meta.value': string | null } => {
+  if (!rawMeta || _isEmpty(rawMeta)) {
+    return {
+      'meta.key': null,
+      'meta.value': null,
+    }
+  }
+
+  return {
+    'meta.key': _keys(rawMeta),
+    'meta.value': _values(rawMeta),
+  }
+}
+
+export const trafficTransformer = (
+  psid: string,
+  sid: string,
+  pid: string,
+  pg: string | null,
+  prev: string | null,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  lc: string | null,
+  ref: string | null,
+  so: string | null,
+  me: string | null,
+  ca: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  meta: Record<string, string> | null,
+  sdur: number,
+  unique: number,
+) => {
+  return {
+    psid,
+    sid,
+    pid,
+    pg: pg || null,
+    prev: prev || null,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    lc: lc || null,
+    ref: ref || null,
+    so: so || null,
+    me: me || null,
+    ca: ca || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    ...processMetaKV(meta),
+    sdur,
+    unique,
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}
+
+export const customEventTransformer = (
+  psid: string,
+  pid: string,
+  ev: string,
+  pg: string | null,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  lc: string | null,
+  ref: string | null,
+  so: string | null,
+  me: string | null,
+  ca: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  meta: Record<string, string> | null,
+) => {
+  return {
+    psid,
+    pid,
+    ev,
+    pg: pg || null,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    lc: lc || null,
+    ref: ref || null,
+    so: so || null,
+    me: me || null,
+    ca: ca || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    ...processMetaKV(meta),
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}
+
+export const errorEventTransformer = (
+  eid: string,
+  pid: string,
+  pg: string | null,
+  dv: string | null,
+  br: string | null,
+  os: string | null,
+  lc: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  name: string | null,
+  message: string | null,
+  lineno: number | null,
+  colno: number | null,
+  filename: string | null,
+) => {
+  return {
+    eid,
+    pid,
+    pg: pg || null,
+    dv: dv || null,
+    br: br || null,
+    os: os || null,
+    lc: lc || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    name: name || null,
+    message: message || null,
+    lineno: lineno || null,
+    colno: colno || null,
+    filename: filename || null,
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}
+
+export const performanceTransformer = (
+  pid: string,
+  pg: string | null,
+  dv: string | null,
+  br: string | null,
+  cc: string | null,
+  rg: string | null,
+  ct: string | null,
+  dns: number,
+  tls: number,
+  conn: number,
+  response: number,
+  render: number,
+  domLoad: number,
+  pageLoad: number,
+  ttfb: number,
+) => {
+  return {
+    pid,
+    pg: pg || null,
+    dv: dv || null,
+    br: br || null,
+    cc: cc || null,
+    rg: rg || null,
+    ct: ct || null,
+    dns: _round(dns),
+    tls: _round(tls),
+    conn: _round(conn),
+    response: _round(response),
+    render: _round(render),
+    domLoad: _round(domLoad),
+    pageLoad: _round(pageLoad),
+    ttfb: _round(ttfb),
+    created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+  }
+}

--- a/apps/selfhosted/src/app.controller.ts
+++ b/apps/selfhosted/src/app.controller.ts
@@ -1,4 +1,5 @@
-import { Get, Controller } from '@nestjs/common'
+import { Get, Controller, OnApplicationShutdown } from '@nestjs/common'
+import { clickhouse } from './common/integrations/clickhouse'
 
 const DEPLOYMENT_INFORMATION = {
   name: 'Swetrix API',
@@ -8,7 +9,11 @@ const DEPLOYMENT_INFORMATION = {
 }
 
 @Controller()
-export class AppController {
+export class AppController implements OnApplicationShutdown {
+  async onApplicationShutdown(): Promise<void> {
+    await clickhouse.close()
+  }
+
   @Get()
   root(): any {
     return DEPLOYMENT_INFORMATION

--- a/apps/selfhosted/src/common/constants.ts
+++ b/apps/selfhosted/src/common/constants.ts
@@ -50,14 +50,9 @@ const isValidPID = (pid: string) => PID_REGEX.test(pid)
 // redis keys
 const getRedisProjectKey = (pid: string) => `pid_${pid}`
 
-const REDIS_LOG_DATA_CACHE_KEY = 'log_cache_v2'
-const REDIS_LOG_CAPTCHA_CACHE_KEY = 'log:captcha'
-const REDIS_LOG_PERF_CACHE_KEY = 'perf_cache'
-const REDIS_LOG_CUSTOM_CACHE_KEY = 'log_custom_cache_v3'
 const REDIS_SESSION_SALT_KEY = 'log_salt' // is updated every 24 hours
 const REDIS_USERS_COUNT_KEY = 'stats:users_count'
 const REDIS_PROJECTS_COUNT_KEY = 'stats:projects_count'
-const REDIS_LOG_ERROR_CACHE_KEY = 'log_error_cache'
 
 // 3600 sec -> 1 hour
 const redisProjectCacheTimeout = 3600
@@ -103,9 +98,6 @@ export {
   getRedisProjectKey,
   redisProjectCacheTimeout,
   UNIQUE_SESSION_LIFE_TIME,
-  REDIS_LOG_DATA_CACHE_KEY,
-  REDIS_LOG_CAPTCHA_CACHE_KEY,
-  REDIS_LOG_CUSTOM_CACHE_KEY,
   TRAFFIC_METAKEY_COLUMNS,
   REDIS_SESSION_SALT_KEY,
   HEARTBEAT_SID_LIFE_TIME,
@@ -119,7 +111,6 @@ export {
   REDIS_PROJECTS_COUNT_KEY,
   IP_REGEX,
   ORIGINS_REGEX,
-  REDIS_LOG_PERF_CACHE_KEY,
   isDevelopment,
   DEFAULT_SELFHOSTED_UUID,
   JWT_ACCESS_TOKEN_SECRET,
@@ -131,7 +122,6 @@ export {
   MIN_PAGES_IN_FUNNEL,
   MAX_PAGES_IN_FUNNEL,
   ERROR_COLUMNS,
-  REDIS_LOG_ERROR_CACHE_KEY,
   PID_REGEX,
   ALL_COLUMNS,
 }

--- a/apps/selfhosted/src/common/constants.ts
+++ b/apps/selfhosted/src/common/constants.ts
@@ -1,4 +1,3 @@
-import { ClickHouse } from 'clickhouse'
 import Redis from 'ioredis'
 import * as _toNumber from 'lodash/toNumber'
 
@@ -6,8 +5,6 @@ import { getSelfhostedUUID } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config()
-
-const { CLICKHOUSE_DATABASE } = process.env
 
 const redis = new Redis(
   _toNumber(process.env.REDIS_PORT),
@@ -22,26 +19,6 @@ const redis = new Redis(
 redis.defineCommand('countKeysByPattern', {
   numberOfKeys: 0,
   lua: "return #redis.call('keys', ARGV[1])",
-})
-
-const clickhouse = new ClickHouse({
-  url: process.env.CLICKHOUSE_HOST,
-  port: _toNumber(process.env.CLICKHOUSE_PORT),
-  debug: false,
-  basicAuth: {
-    username: process.env.CLICKHOUSE_USER,
-    password: process.env.CLICKHOUSE_PASSWORD,
-  },
-  isUseGzip: false,
-  format: 'json',
-  raw: false,
-  config: {
-    session_timeout: 60,
-    output_format_json_quote_64bit_integers: 0,
-    enable_http_compression: 0,
-    database: CLICKHOUSE_DATABASE,
-    log_queries: 0,
-  },
 })
 
 const {
@@ -121,7 +98,6 @@ const NUMBER_JWT_REFRESH_TOKEN_LIFETIME = Number(JWT_REFRESH_TOKEN_LIFETIME)
 const NUMBER_JWT_ACCESS_TOKEN_LIFETIME = Number(JWT_ACCESS_TOKEN_LIFETIME)
 
 export {
-  clickhouse,
   redis,
   isValidPID,
   getRedisProjectKey,

--- a/apps/selfhosted/src/common/integrations/clickhouse.ts
+++ b/apps/selfhosted/src/common/integrations/clickhouse.ts
@@ -15,6 +15,11 @@ const clickhouse = createClient({
     output_format_json_quote_64bit_integers: 0,
     enable_http_compression: 0,
     log_queries: 0,
+
+    // Used for analytics & captcha stuff.
+    // https://clickhouse.com/docs/en/optimize/asynchronous-inserts
+    wait_for_async_insert: 0, // Return ACK (await) when row was added to the buffer, not flushed to the database
+    async_insert_busy_timeout_ms: 15000, // 15 seconds; this is how long the buffer will be kept before writing stuff into the database
   },
 })
 

--- a/apps/selfhosted/src/common/integrations/clickhouse.ts
+++ b/apps/selfhosted/src/common/integrations/clickhouse.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@clickhouse/client'
+
+const clickhouse = createClient({
+  host: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
+  username: process.env.CLICKHOUSE_USER,
+  password: process.env.CLICKHOUSE_PASSWORD,
+  database: process.env.CLICKHOUSE_DATABASE,
+  request_timeout: 60000, // 1 minute
+  clickhouse_settings: {
+    connect_timeout: 60000,
+    date_time_output_format: 'iso',
+    max_download_buffer_size: (10 * 1024 * 1024).toString(),
+    max_download_threads: 32,
+    max_execution_time: 60000,
+    output_format_json_quote_64bit_integers: 0,
+    enable_http_compression: 0,
+    log_queries: 0,
+  },
+})
+
+export { clickhouse }

--- a/apps/selfhosted/src/common/integrations/clickhouse.ts
+++ b/apps/selfhosted/src/common/integrations/clickhouse.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@clickhouse/client'
 
 const clickhouse = createClient({
-  host: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
+  url: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
   username: process.env.CLICKHOUSE_USER,
   password: process.env.CLICKHOUSE_PASSWORD,
   database: process.env.CLICKHOUSE_DATABASE,

--- a/apps/selfhosted/src/common/utils.ts
+++ b/apps/selfhosted/src/common/utils.ts
@@ -156,18 +156,21 @@ const deleteFunnelClickhouse = async (id: string) => {
 }
 
 const createFunnelClickhouse = async (funnel: Partial<Funnel>) => {
-  const query = `INSERT INTO funnel (*) VALUES ({id:String},{name:String},{steps:String},{projectId:FixedString(12)},'${dayjs
-    .utc()
-    .format('YYYY-MM-DD HH:mm:ss')}')`
+  const { id, name, steps, projectId } = funnel
 
-  const { data } = await clickhouse
-    .query({
-      query,
-      query_params: funnel,
-    })
-    .then(resultSet => resultSet.json())
-
-  return data
+  await clickhouse.insert({
+    table: 'funnel',
+    format: 'JSONEachRow',
+    values: [
+      {
+        id,
+        name,
+        steps,
+        projectId,
+        created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+      },
+    ],
+  })
 }
 
 const getProjectsClickhouse = async (id = null, search: string = null) => {
@@ -287,37 +290,41 @@ const deleteProjectClickhouse = async (id: string) => {
 }
 
 const createProjectClickhouse = async (project: Partial<Project>) => {
-  const created = dayjs.utc().format('YYYY-MM-DD HH:mm:ss')
-  const query = `INSERT INTO project (*) VALUES ({id:FixedString(12)},{name:String},'','',1,0,0,NULL,'${created}')`
+  const { id, name } = project
 
-  const { data } = await clickhouse
-    .query({
-      query,
-      query_params: project,
-    })
-    .then(resultSet => resultSet.json())
-
-  return data
+  await clickhouse.insert({
+    table: 'project',
+    format: 'JSONEachRow',
+    values: [
+      {
+        id,
+        name,
+        origins: '',
+        ipBlacklist: '',
+        active: 1,
+        public: 0,
+        isPasswordProtected: 0,
+        passwordHash: null,
+        created: dayjs.utc().format('YYYY-MM-DD HH:mm:ss'),
+      },
+    ],
+  })
 }
 
 const saveRefreshTokenClickhouse = async (
   userId: string,
   refreshToken: string,
 ) => {
-  const query =
-    'INSERT INTO refresh_token (*) VALUES ({userId:String},{refreshToken:String})'
-
-  const { data } = await clickhouse
-    .query({
-      query,
-      query_params: {
+  await clickhouse.insert({
+    table: 'refresh_token',
+    format: 'JSONEachRow',
+    values: [
+      {
         userId,
         refreshToken,
       },
-    })
-    .then(resultSet => resultSet.json())
-
-  return data
+    ],
+  })
 }
 
 const findRefreshTokenClickhouse = async (
@@ -368,19 +375,20 @@ interface IClickhouseUser {
 const CLICKHOUSE_SETTINGS_ID = 'sfuser'
 
 const createUserClickhouse = async (user: IClickhouseUser) => {
-  const query = `INSERT INTO sfuser (*) VALUES ({id:String},{timezone:String},{timeFormat:String},{showLiveVisitorsInTitle:Int8})`
+  const { timezone, timeFormat, showLiveVisitorsInTitle } = user
 
-  const { data } = await clickhouse
-    .query({
-      query,
-      query_params: {
-        ...user,
+  await clickhouse.insert({
+    table: 'sfuser',
+    format: 'JSONEachRow',
+    values: [
+      {
         id: CLICKHOUSE_SETTINGS_ID,
+        timezone,
+        timeFormat,
+        showLiveVisitorsInTitle,
       },
-    })
-    .then(resultSet => resultSet.json())
-
-  return data
+    ],
+  })
 }
 
 const getUserClickhouse = async () => {

--- a/apps/selfhosted/src/common/utils.ts
+++ b/apps/selfhosted/src/common/utils.ts
@@ -19,7 +19,6 @@ import * as utc from 'dayjs/plugin/utc'
 import * as _map from 'lodash/map'
 
 import {
-  clickhouse,
   redis,
   DEFAULT_SELFHOSTED_UUID,
   SELFHOSTED_EMAIL,
@@ -27,6 +26,7 @@ import {
   isDevelopment,
   isProxiedByCloudflare,
 } from './constants'
+import { clickhouse } from './integrations/clickhouse'
 import { DEFAULT_TIMEZONE, TimeFormat } from '../user/entities/user.entity'
 import { Project } from '../project/entity/project.entity'
 import { Funnel } from '../project/entity/funnel.entity'
@@ -72,17 +72,23 @@ const checkRateLimit = async (
 }
 
 const getFunnelsClickhouse = async (projectId: string, funnelId = null) => {
-  const paramsData = {
-    params: {
-      projectId,
-      funnelId,
-    },
+  const queryParams = {
+    projectId,
+    funnelId,
   }
 
   if (!funnelId) {
     const query =
       'SELECT * FROM funnel WHERE projectId = {projectId:FixedString(12)}'
-    return clickhouse.query(query, paramsData).toPromise()
+
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: queryParams,
+      })
+      .then(resultSet => resultSet.json())
+
+    return data
   }
 
   const query = `
@@ -93,15 +99,20 @@ const getFunnelsClickhouse = async (projectId: string, funnelId = null) => {
       projectId = {projectId:FixedString(12)}
       AND id = {funnelId:String}`
 
-  const funnel = await clickhouse.query(query, paramsData).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: queryParams,
+    })
+    .then(resultSet => resultSet.json())
 
-  if (_isEmpty(funnel)) {
+  if (_isEmpty(data)) {
     throw new NotFoundException(
       `Funnel ${funnelId} was not found in the database`,
     )
   }
 
-  return _head(funnel)
+  return _head(data)
 }
 
 const updateFunnelClickhouse = async (funnel: any) => {
@@ -120,43 +131,48 @@ const updateFunnelClickhouse = async (funnel: any) => {
     ', ',
   )} WHERE id='${funnel.id}'`
 
-  return clickhouse.query(query).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const deleteFunnelClickhouse = async (id: string) => {
-  const paramsData = {
-    params: {
-      id,
-    },
-  }
-
   const query = `ALTER table funnel DELETE WHERE id = {id:String}`
-  return clickhouse.query(query, paramsData).toPromise()
+
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        id,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const createFunnelClickhouse = async (funnel: Partial<Funnel>) => {
-  const paramsData = {
-    params: {
-      ...funnel,
-    },
-  }
-
   const query = `INSERT INTO funnel (*) VALUES ({id:String},{name:String},{steps:String},{projectId:FixedString(12)},'${dayjs
     .utc()
     .format('YYYY-MM-DD HH:mm:ss')}')`
 
-  return clickhouse.query(query, paramsData).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: funnel,
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const getProjectsClickhouse = async (id = null, search: string = null) => {
   if (!id) {
     if (search) {
-      const paramsData = {
-        params: {
-          search: `%${search}%`,
-        },
-      }
-
       const query = `
         SELECT
           *
@@ -164,29 +180,48 @@ const getProjectsClickhouse = async (id = null, search: string = null) => {
         WHERE
           name ILIKE {search:String} OR
           id ILIKE {search:String}
-        ORDER BY created ASC`
+        ORDER BY created ASC
+      `
 
-      return clickhouse.query(query, paramsData).toPromise()
+      const { data } = await clickhouse
+        .query({
+          query,
+          query_params: {
+            search: `%${search}%`,
+          },
+        })
+        .then(resultSet => resultSet.json())
+
+      return data
     }
 
     const query = 'SELECT * FROM project ORDER BY created ASC;'
-    return clickhouse.query(query).toPromise()
-  }
 
-  const paramsData = {
-    params: {
-      id,
-    },
+    const { data } = await clickhouse
+      .query({
+        query,
+      })
+      .then(resultSet => resultSet.json())
+
+    return data
   }
 
   const query = `SELECT * FROM project WHERE id = {id:FixedString(12)};`
-  const project = await clickhouse.query(query, paramsData).toPromise()
 
-  if (_isEmpty(project)) {
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        id,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  if (_isEmpty(data)) {
     throw new NotFoundException(`Project ${id} was not found in the database`)
   }
 
-  return _head(project)
+  return _head(data)
 }
 
 const updateProjectClickhouse = async (project: any) => {
@@ -204,7 +239,14 @@ const updateProjectClickhouse = async (project: any) => {
     _map(columns, (col, id) => `${col}='${values[id]}'`),
     ', ',
   )} WHERE id='${project.id}'`
-  return clickhouse.query(query).toPromise()
+
+  const { data } = await clickhouse
+    .query({
+      query,
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 /**
@@ -230,71 +272,91 @@ const calculateRelativePercentage = (
 }
 
 const deleteProjectClickhouse = async (id: string) => {
-  const paramsData = {
-    params: {
-      id,
-    },
-  }
-
   const query = `ALTER table project DELETE WHERE id = {id:FixedString(12)}`
-  return clickhouse.query(query, paramsData).toPromise()
+
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        id,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const createProjectClickhouse = async (project: Partial<Project>) => {
-  const paramsData = {
-    params: {
-      ...project,
-    },
-  }
   const created = dayjs.utc().format('YYYY-MM-DD HH:mm:ss')
   const query = `INSERT INTO project (*) VALUES ({id:FixedString(12)},{name:String},'','',1,0,0,NULL,'${created}')`
 
-  return clickhouse.query(query, paramsData).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: project,
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const saveRefreshTokenClickhouse = async (
   userId: string,
   refreshToken: string,
 ) => {
-  const paramsData = {
-    params: {
-      userId,
-      refreshToken,
-    },
-  }
   const query =
     'INSERT INTO refresh_token (*) VALUES ({userId:String},{refreshToken:String})'
 
-  return clickhouse.query(query, paramsData).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        userId,
+        refreshToken,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const findRefreshTokenClickhouse = async (
   userId: string,
   refreshToken: string,
 ) => {
-  const paramsData = {
-    params: {
-      userId,
-      refreshToken,
-    },
-  }
   const query =
     'SELECT * FROM refresh_token WHERE userId = {userId:String} AND refreshToken = {refreshToken:String}'
-  return clickhouse.query(query, paramsData).toPromise()
+
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        userId,
+        refreshToken,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const deleteRefreshTokenClickhouse = async (
   userId: string,
   refreshToken: string,
 ) => {
-  const paramsData = {
-    params: {
-      userId,
-      refreshToken,
-    },
-  }
   const query = `ALTER table refresh_token DELETE WHERE userId = {userId:String} AND refreshToken = {refreshToken:String}`
-  return clickhouse.query(query, paramsData).toPromise()
+
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        userId,
+        refreshToken,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 interface IClickhouseUser {
@@ -306,29 +368,35 @@ interface IClickhouseUser {
 const CLICKHOUSE_SETTINGS_ID = 'sfuser'
 
 const createUserClickhouse = async (user: IClickhouseUser) => {
-  const paramsData = {
-    params: {
-      ...user,
-      id: CLICKHOUSE_SETTINGS_ID,
-    },
-  }
-
   const query = `INSERT INTO sfuser (*) VALUES ({id:String},{timezone:String},{timeFormat:String},{showLiveVisitorsInTitle:Int8})`
 
-  return clickhouse.query(query, paramsData).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        ...user,
+        id: CLICKHOUSE_SETTINGS_ID,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const getUserClickhouse = async () => {
-  const paramsData = {
-    params: {
-      id: CLICKHOUSE_SETTINGS_ID,
-    },
-  }
-
   const query = `SELECT * FROM sfuser WHERE id = {id:String}`
 
   try {
-    return (await clickhouse.query(query, paramsData).toPromise())[0] || {}
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: {
+          id: CLICKHOUSE_SETTINGS_ID,
+        },
+      })
+      .then(resultSet => resultSet.json())
+
+    return data[0] || {}
   } catch {
     return {}
   }
@@ -338,8 +406,13 @@ const userClickhouseExists = async () => {
   const query = `SELECT * FROM sfuser WHERE id = '${CLICKHOUSE_SETTINGS_ID}'`
 
   try {
-    const result = await clickhouse.query(query).toPromise()
-    return !_isEmpty(result)
+    const { data } = await clickhouse
+      .query({
+        query,
+      })
+      .then(resultSet => resultSet.json())
+
+    return !_isEmpty(data)
   } catch {
     return false
   }
@@ -355,13 +428,6 @@ const updateUserClickhouse = async (user: IClickhouseUser) => {
       showLiveVisitorsInTitle: 0,
       ...user,
     })
-  }
-
-  const paramsData = {
-    params: {
-      ...user,
-      id: CLICKHOUSE_SETTINGS_ID,
-    },
   }
 
   let query = 'ALTER table sfuser UPDATE '
@@ -384,7 +450,17 @@ const updateUserClickhouse = async (user: IClickhouseUser) => {
 
   query += ` WHERE id={id:String}`
 
-  return clickhouse.query(query, paramsData).toPromise()
+  const { data } = await clickhouse
+    .query({
+      query,
+      query_params: {
+        ...user,
+        id: CLICKHOUSE_SETTINGS_ID,
+      },
+    })
+    .then(resultSet => resultSet.json())
+
+  return data
 }
 
 const millisecondsToSeconds = (milliseconds: number) => milliseconds / 1000

--- a/apps/selfhosted/src/main.ts
+++ b/apps/selfhosted/src/main.ts
@@ -51,6 +51,8 @@ async function bootstrap() {
     next()
   })
 
+  app.enableShutdownHooks()
+
   await app.listen(5005)
 }
 bootstrap()

--- a/apps/selfhosted/src/project/project.controller.ts
+++ b/apps/selfhosted/src/project/project.controller.ts
@@ -52,7 +52,8 @@ import {
   FunnelUpdateDTO,
 } from './dto'
 import { AppLoggerService } from '../logger/logger.service'
-import { isValidPID, clickhouse } from '../common/constants'
+import { isValidPID } from '../common/constants'
+import { clickhouse } from '../common/integrations/clickhouse'
 import {
   getProjectsClickhouse,
   createProjectClickhouse,
@@ -201,12 +202,13 @@ export class ProjectController {
       )
     }
 
-    const query1 = `ALTER table analytics DELETE WHERE pid='${id}'`
-    const query2 = `ALTER table customEV DELETE WHERE pid='${id}'`
-
     try {
-      await clickhouse.query(query1).toPromise()
-      await clickhouse.query(query2).toPromise()
+      await clickhouse.query({
+        query: `ALTER table analytics DELETE WHERE pid='${id}'`,
+      })
+      await clickhouse.query({
+        query: `ALTER table customEV DELETE WHERE pid='${id}'`,
+      })
       return 'Project resetted successfully'
     } catch (e) {
       this.logger.error(e)
@@ -433,12 +435,13 @@ export class ProjectController {
 
     await deleteProjectClickhouse(id)
 
-    const query1 = `ALTER table analytics DELETE WHERE pid='${id}'`
-    const query2 = `ALTER table customEV DELETE WHERE pid='${id}'`
-
     try {
-      await clickhouse.query(query1).toPromise()
-      await clickhouse.query(query2).toPromise()
+      await clickhouse.query({
+        query: `ALTER table analytics DELETE WHERE pid='${id}'`,
+      })
+      await clickhouse.query({
+        query: `ALTER table customEV DELETE WHERE pid='${id}'`,
+      })
       return 'Project deleted successfully'
     } catch (e) {
       this.logger.error(e)

--- a/apps/selfhosted/src/project/project.service.ts
+++ b/apps/selfhosted/src/project/project.service.ts
@@ -241,6 +241,10 @@ export class ProjectService {
       'ALTER TABLE customEV DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
     const queryPerformance =
       'ALTER TABLE performance DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
+    const queryErrors =
+      'ALTER TABLE errors DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
+    const queryErrorStatuses =
+      'ALTER TABLE error_statuses DELETE WHERE pid = {pid:FixedString(12)} AND created BETWEEN {from:String} AND {to:String}'
     const params = {
       params: {
         pid,
@@ -249,18 +253,28 @@ export class ProjectService {
       },
     }
 
-    await clickhouse.query({
-      query: queryAnalytics,
-      query_params: params,
-    })
-    await clickhouse.query({
-      query: queryCustomEvents,
-      query_params: params,
-    })
-    await clickhouse.query({
-      query: queryPerformance,
-      query_params: params,
-    })
+    await Promise.all([
+      clickhouse.query({
+        query: queryAnalytics,
+        query_params: params,
+      }),
+      clickhouse.query({
+        query: queryCustomEvents,
+        query_params: params,
+      }),
+      clickhouse.query({
+        query: queryPerformance,
+        query_params: params,
+      }),
+      clickhouse.query({
+        query: queryErrors,
+        query_params: params,
+      }),
+      clickhouse.query({
+        query: queryErrorStatuses,
+        query_params: params,
+      }),
+    ])
   }
 
   formatToClickhouse(project: any): object {

--- a/apps/selfhosted/src/task-manager/task-manager.service.ts
+++ b/apps/selfhosted/src/task-manager/task-manager.service.ts
@@ -3,21 +3,11 @@ import { Cron, CronExpression } from '@nestjs/schedule'
 import * as bcrypt from 'bcrypt'
 import * as dayjs from 'dayjs'
 import * as utc from 'dayjs/plugin/utc'
-import * as _isEmpty from 'lodash/isEmpty'
-import * as _join from 'lodash/join'
 import * as _size from 'lodash/size'
 import * as _map from 'lodash/map'
 import * as _now from 'lodash/now'
 
-import {
-  redis,
-  REDIS_LOG_DATA_CACHE_KEY,
-  REDIS_LOG_CUSTOM_CACHE_KEY,
-  REDIS_SESSION_SALT_KEY,
-  REDIS_LOG_PERF_CACHE_KEY,
-  REDIS_LOG_CAPTCHA_CACHE_KEY,
-  REDIS_LOG_ERROR_CACHE_KEY,
-} from '../common/constants'
+import { redis, REDIS_SESSION_SALT_KEY } from '../common/constants'
 import { clickhouse } from '../common/integrations/clickhouse'
 import { AppLoggerService } from '../logger/logger.service'
 
@@ -26,87 +16,6 @@ dayjs.extend(utc)
 @Injectable()
 export class TaskManagerService {
   constructor(private readonly logger: AppLoggerService) {}
-
-  @Cron(CronExpression.EVERY_MINUTE)
-  async saveLogData(): Promise<void> {
-    const data = await redis.lrange(REDIS_LOG_DATA_CACHE_KEY, 0, -1)
-    const customData = await redis.lrange(REDIS_LOG_CUSTOM_CACHE_KEY, 0, -1)
-    const perfData = await redis.lrange(REDIS_LOG_PERF_CACHE_KEY, 0, -1)
-    const captchaData = await redis.lrange(REDIS_LOG_CAPTCHA_CACHE_KEY, 0, -1)
-    const errorData = await redis.lrange(REDIS_LOG_ERROR_CACHE_KEY, 0, -1)
-
-    if (!_isEmpty(data)) {
-      await redis.del(REDIS_LOG_DATA_CACHE_KEY)
-      const query = `INSERT INTO analytics (*) VALUES ${_join(data, ',')}`
-      try {
-        await clickhouse.query({
-          query,
-        })
-      } catch (e) {
-        console.error(`[CRON WORKER] Error whilst saving log data: ${e}`)
-      }
-    }
-
-    if (!_isEmpty(captchaData)) {
-      await redis.del(REDIS_LOG_CAPTCHA_CACHE_KEY)
-      const query = `INSERT INTO captcha (*) VALUES ${_join(captchaData, ',')}`
-      try {
-        await clickhouse.query({
-          query,
-        })
-      } catch (e) {
-        console.error(
-          `[CRON WORKER] Error whilst saving CAPTCHA log data: ${e}`,
-        )
-      }
-    }
-
-    if (!_isEmpty(customData)) {
-      await redis.del(REDIS_LOG_CUSTOM_CACHE_KEY)
-      const query = `INSERT INTO customEV (*) VALUES ${_join(customData, ',')}`
-
-      try {
-        await clickhouse.query({
-          query,
-        })
-      } catch (e) {
-        console.error(
-          `[CRON WORKER] Error whilst saving custom events data: ${e}`,
-        )
-      }
-    }
-
-    if (!_isEmpty(errorData)) {
-      await redis.del(REDIS_LOG_ERROR_CACHE_KEY)
-      const query = `INSERT INTO errors (*) VALUES ${_join(errorData, ',')}`
-
-      try {
-        await clickhouse.query({
-          query,
-        })
-      } catch (e) {
-        console.error(
-          `[CRON WORKER] Error whilst saving error events data: ${e}`,
-        )
-      }
-    }
-
-    if (!_isEmpty(perfData)) {
-      await redis.del(REDIS_LOG_PERF_CACHE_KEY)
-
-      const query = `INSERT INTO performance (*) VALUES ${_join(perfData, ',')}`
-
-      try {
-        await clickhouse.query({
-          query,
-        })
-      } catch (e) {
-        console.error(
-          `[CRON WORKER] Error whilst saving performance data: ${e}`,
-        )
-      }
-    }
-  }
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async generateSessionSalt(): Promise<void> {

--- a/apps/selfhosted/src/task-manager/task-manager.service.ts
+++ b/apps/selfhosted/src/task-manager/task-manager.service.ts
@@ -10,7 +10,6 @@ import * as _map from 'lodash/map'
 import * as _now from 'lodash/now'
 
 import {
-  clickhouse,
   redis,
   REDIS_LOG_DATA_CACHE_KEY,
   REDIS_LOG_CUSTOM_CACHE_KEY,
@@ -19,6 +18,7 @@ import {
   REDIS_LOG_CAPTCHA_CACHE_KEY,
   REDIS_LOG_ERROR_CACHE_KEY,
 } from '../common/constants'
+import { clickhouse } from '../common/integrations/clickhouse'
 import { AppLoggerService } from '../logger/logger.service'
 
 dayjs.extend(utc)
@@ -39,7 +39,9 @@ export class TaskManagerService {
       await redis.del(REDIS_LOG_DATA_CACHE_KEY)
       const query = `INSERT INTO analytics (*) VALUES ${_join(data, ',')}`
       try {
-        await clickhouse.query(query).toPromise()
+        await clickhouse.query({
+          query,
+        })
       } catch (e) {
         console.error(`[CRON WORKER] Error whilst saving log data: ${e}`)
       }
@@ -49,7 +51,9 @@ export class TaskManagerService {
       await redis.del(REDIS_LOG_CAPTCHA_CACHE_KEY)
       const query = `INSERT INTO captcha (*) VALUES ${_join(captchaData, ',')}`
       try {
-        await clickhouse.query(query).toPromise()
+        await clickhouse.query({
+          query,
+        })
       } catch (e) {
         console.error(
           `[CRON WORKER] Error whilst saving CAPTCHA log data: ${e}`,
@@ -62,7 +66,9 @@ export class TaskManagerService {
       const query = `INSERT INTO customEV (*) VALUES ${_join(customData, ',')}`
 
       try {
-        await clickhouse.query(query).toPromise()
+        await clickhouse.query({
+          query,
+        })
       } catch (e) {
         console.error(
           `[CRON WORKER] Error whilst saving custom events data: ${e}`,
@@ -75,7 +81,9 @@ export class TaskManagerService {
       const query = `INSERT INTO errors (*) VALUES ${_join(errorData, ',')}`
 
       try {
-        await clickhouse.query(query).toPromise()
+        await clickhouse.query({
+          query,
+        })
       } catch (e) {
         console.error(
           `[CRON WORKER] Error whilst saving error events data: ${e}`,
@@ -89,7 +97,9 @@ export class TaskManagerService {
       const query = `INSERT INTO performance (*) VALUES ${_join(perfData, ',')}`
 
       try {
-        await clickhouse.query(query).toPromise()
+        await clickhouse.query({
+          query,
+        })
       } catch (e) {
         console.error(
           `[CRON WORKER] Error whilst saving performance data: ${e}`,
@@ -111,7 +121,9 @@ export class TaskManagerService {
       .subtract(20, 'm')
       .format('YYYY-MM-DD HH:mm:ss')}'`
 
-    await clickhouse.query(delSidQuery).toPromise()
+    await clickhouse.query({
+      query: delSidQuery,
+    })
   }
 
   @Cron(CronExpression.EVERY_MINUTE)
@@ -148,7 +160,9 @@ export class TaskManagerService {
         ([key]) => `'${key.split(':')[1]}'`,
       ).join(',')})`
 
-      await clickhouse.query(setSdurQuery).toPromise()
+      await clickhouse.query({
+        query: setSdurQuery,
+      })
     }
   }
 
@@ -163,7 +177,9 @@ export class TaskManagerService {
     ]
 
     const promises = _map(queries, async query => {
-      await clickhouse.query(query).toPromise()
+      await clickhouse.query({
+        query,
+      })
     })
 
     await Promise.allSettled(promises).catch(reason => {

--- a/migrations/clickhouse/setup.js
+++ b/migrations/clickhouse/setup.js
@@ -5,7 +5,7 @@ const chalk = require('chalk')
 require('dotenv').config()
 
 const clickhouse = createClient({
-  host: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
+  url: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
   username: process.env.CLICKHOUSE_USER,
   password: process.env.CLICKHOUSE_PASSWORD,
   database: process.env.CLICKHOUSE_DATABASE,
@@ -23,7 +23,7 @@ const clickhouse = createClient({
 })
 
 const clickhouseNoDatabase = createClient({
-  host: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
+  url: `${process.env.CLICKHOUSE_HOST}:${process.env.CLICKHOUSE_PORT}`,
   username: process.env.CLICKHOUSE_USER,
   password: process.env.CLICKHOUSE_PASSWORD,
   request_timeout: 60000, // 1 minute

--- a/migrations/clickhouse/setup.js
+++ b/migrations/clickhouse/setup.js
@@ -49,7 +49,7 @@ const databaselessQueriesRunner = async queries => {
     if (query) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        await clickhouseNoDatabase.query({
+        await clickhouseNoDatabase.command({
           query,
         })
         console.log(chalk.green('Query OK: '), query)
@@ -73,7 +73,7 @@ const queriesRunner = async (queries, log = true) => {
     if (query) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        await clickhouse.query({
+        await clickhouse.command({
           query,
         })
 

--- a/migrations/clickhouse/test_migration.js
+++ b/migrations/clickhouse/test_migration.js
@@ -1,7 +1,5 @@
 const { queriesRunner, dbName } = require('./setup')
 
-const queries = [
-  `SELECT * FROM ${dbName}.analytics LIMIT 10`,
-]
+const queries = [`SELECT * FROM ${dbName}.analytics LIMIT 10`]
 
 queriesRunner(queries)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org my-org-f6 --project swetrix-api ./dist && sentry-cli sourcemaps upload --org my-org-f6 --project swetrix-api ./dist"
   },
   "dependencies": {
+    "@clickhouse/client": "^1.4.0",
     "@faker-js/faker": "^8.4.1",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "chalk": "^4.1.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
-    "clickhouse": "^2.6.0",
     "cookie-parser": "^1.4.6",
     "countries-and-timezones": "^3.5.2",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
### Ticket
https://github.com/Swetrix/roadmap/issues/217

1. Migrated everything from `clickhouse` to `@clickhouse/client` - now everything is much easier to use and maintain, there's also no need to write raw (parametrised) SQL insert queries, because the new library offers lots of methods for that.
2. Dropped `Redis` for analytics data queuing. Now we rely on asynchronous queries for that. Clickhouse server will create batches on it's own and inject them into the database whenever it's ready. Now the data will be saved to the DB and displayed in dashboard almost instantly.
![image](https://github.com/user-attachments/assets/b0dae7f0-ecc2-4d96-9638-026107c86c18)

3. Errors like `Error: 500: Code: 241. DB::Exception: Memory limit (total) exceeded: would use x.xx GiB (attempt to allocate chunk of xxxxxxx bytes), maximum: x.xx GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker. (MEMORY_LIMIT_EXCEEDED) (version x.x.x.xx (official build))` will now be prevented because chunks are managed server-side.




### Self-hosted support
- [x] Your feature is implemented for the selfhosted version of Swetrix
- [ ] This PR only updates the production code (e.g. paddle webhooks, CAPTCHA, blog, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints
