### PR TITLE
Adapt self-hosting documentation for v5

### DIFF
--- a/docs/docs/selfhosting/how-to.md
+++ b/docs/docs/selfhosting/how-to.md
@@ -68,7 +68,7 @@ After starting the container you can access the dashboard at `http://{host}:80` 
 
 ## Updating
 
-To update Swetrix to the latest version, please refer to the changelog on our GitHub repository (https://github.com/Swetrix/swetrix/releases).
+To update Swetrix to the latest version, please refer to the [changelog on our GitHub repository](https://github.com/Swetrix/swetrix/releases).
 Usually, Swetrix releases come with database migrations that you'll need to apply manually. So make sure to backup your database before updating and follow the changelog instructions carefully.
 
 ## Reverse proxy & Swetrix v5 routing


### PR DESCRIPTION
Adapted self-hosting documentation for v5 with nginx proxy container explanation, ports and also how to use Swetrix with traefik instead of the included nginx.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting guide for v5 single-entrypoint routing: default frontend at / and API at /backend.
  * Clarified internal port mappings (frontend 3000, API 5005) and added nginx-proxy as the recommended routing layer.
  * Replaced generic reverse-proxy guidance with explicit nginx-proxy and Traefik examples (TLS, routing rules, labels).
  * Consolidated Client IP header guidance for Cloudflare and non-Cloudflare setups; broadened dashboard access notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->