### PR TITLE
fix: Invalidate password reset tokens when password has been reset

### DIFF
--- a/backend/apps/cloud/src/user/user.controller.ts
+++ b/backend/apps/cloud/src/user/user.controller.ts
@@ -659,16 +659,18 @@ export class UserController {
       ])
       await this.userService.update(id, userToUpdate)
 
-      // If password should have been updated and there were no issues doing so, then...
       if (shouldUpdatePassword) {
-        // Send 'Password changed' email notification
-        await this.mailerService.sendEmail(
-          user.email,
-          LetterTemplate.PasswordChanged,
-        )
-
-        // Log out all user sessions
-        await this.authService.logoutAll(id)
+        await Promise.all([
+          this.mailerService.sendEmail(
+            user.email,
+            LetterTemplate.PasswordChanged,
+          ),
+          this.authService.logoutAll(id),
+          this.actionTokensService.deleteMultiple({
+            user: { id },
+            action: ActionTokenType.PASSWORD_RESET,
+          }),
+        ])
       }
 
       const updatedUser = await this.userService.findOne({ where: { id } })

--- a/backend/apps/community/src/auth/auth.service.ts
+++ b/backend/apps/community/src/auth/auth.service.ts
@@ -212,6 +212,42 @@ export class AuthService {
     )
   }
 
+  public async invalidatePasswordResetTokens(userId: string): Promise<void> {
+    try {
+      let cursor = '0'
+      const scanCount = 100
+
+      do {
+        const [nextCursor, keys] = await redis.scan(
+          cursor,
+          'MATCH',
+          'password_reset:*',
+          'COUNT',
+          scanCount,
+        )
+
+        if (keys && keys.length > 0) {
+          const values = await redis.mget(...keys)
+          const pipeline = redis.pipeline()
+
+          for (let i = 0; i < keys.length; i++) {
+            if (values[i] === userId) {
+              pipeline.del(keys[i])
+            }
+          }
+
+          await pipeline.exec()
+        }
+
+        cursor = nextCursor
+      } while (cursor !== '0')
+    } catch (reason) {
+      console.error(
+        `[ERROR][AuthService -> invalidatePasswordResetTokens]: ${reason}`,
+      )
+    }
+  }
+
   public async resetPassword(userId: string, password: string): Promise<void> {
     const hashedPassword = await this.hashPassword(password)
 

--- a/backend/apps/community/src/user/user.controller.ts
+++ b/backend/apps/community/src/user/user.controller.ts
@@ -343,11 +343,14 @@ export class UserController {
         const hashed = await this.authService.hashPassword(userDTO.password)
         await this.userService.update(id, { password: hashed })
 
-        await this.mailerService.sendEmail(
-          originalUser.email,
-          LetterTemplate.PasswordChanged,
-        )
-        await this.authService.logoutAll(id)
+        await Promise.all([
+          this.mailerService.sendEmail(
+            originalUser.email,
+            LetterTemplate.PasswordChanged,
+          ),
+          this.authService.logoutAll(id),
+          this.authService.invalidatePasswordResetTokens(id),
+        ])
       }
 
       if (userDTO.email && userDTO.email !== originalUser.email) {


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [ ] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [ ] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [ ] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password change security: When users change their password, the system now immediately invalidates all existing password reset tokens alongside session logout, executed concurrently for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->