### PR TITLE
(fix) 2FA setup and /tools/qr-code-generator crash on v5.2.1

### DIFF
--- a/web/app/pages/UserSettings/components/TwoFA.tsx
+++ b/web/app/pages/UserSettings/components/TwoFA.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import QRCode from 'react-qr-code'
+import { QRCode } from 'react-qr-code'
 import { useFetcher } from 'react-router'
 import { toast } from 'sonner'
 import { LockIcon } from '@phosphor-icons/react'

--- a/web/app/routes/tools.qr-code-generator.tsx
+++ b/web/app/routes/tools.qr-code-generator.tsx
@@ -1,6 +1,6 @@
 import { DownloadIcon } from '@phosphor-icons/react'
 import { useState } from 'react'
-import QRCode from 'react-qr-code'
+import { QRCode } from 'react-qr-code'
 import type { MetaFunction } from 'react-router'
 import { redirect } from 'react-router'
 import type { SitemapFunction } from 'remix-sitemap'

--- a/web/app/types.d.ts
+++ b/web/app/types.d.ts
@@ -1,0 +1,24 @@
+// Module augmentation for `react-qr-code`.
+//
+// The upstream package ships only a default export in its `.d.ts`, but the
+// CJS entry assigns the same component to `exports.QRCode` as well. Vite 8 /
+// Rolldown's `__toESM` helper produces a broken default-interop wrapper for
+// CJS modules whose source already declares `__esModule: true` and its own
+// `default` (the synthetic `.default` ends up pointing at the whole module
+// object instead of the component, so `<QRCode />` renders an object and
+// throws). Importing the existing-but-undeclared `QRCode` named export
+// sidesteps the wrapper.
+declare module 'react-qr-code' {
+  import type { ComponentType, SVGProps, CSSProperties } from 'react'
+
+  export interface QRCodeProps extends SVGProps<SVGSVGElement> {
+    value: string
+    size?: number
+    bgColor?: CSSProperties['backgroundColor']
+    fgColor?: CSSProperties['color']
+    level?: 'L' | 'M' | 'H' | 'Q'
+    title?: string
+  }
+
+  export const QRCode: ComponentType<QRCodeProps>
+}


### PR DESCRIPTION
### Changes

Fixes a regression introduced in v5.2.1 where:

- Clicking **Enable 2FA** on `/user-settings?tab=password-auth` crashes the page with `Minified React error #130` ("Element type is invalid: expected a string or class/function but got: object"), preceded by `#418` (hydration mismatch) as the router error boundary remounts.
- The public `/tools/qr-code-generator` page crashes the same way as soon as the user types into the input.

Both routes render `<QRCode>` from `react-qr-code` via the default import.

#### Root cause

v5.2.1 bumped `vite ^7.3.1 -> ^8.0.7`. Vite 8 switched the default bundler from Rollup to Rolldown. For default imports of CJS modules, Rolldown emits `__toESM(mod, /* isNodeMode */ 1)`. With `isNodeMode=1` the helper writes `synth.default = wholeModule` *even when the source already declares its own `default` export*, so:

```js
import QRCode from 'react-qr-code'
```

ends up as the whole module object `{ __esModule: true, default: fn, QRCode: fn }` instead of the component, and `<QRCode />` (compiled to `createElement(default, …)`) tries to render an object.

`react-qr-code@2.0.18` is exactly the shape that triggers this — it ships only a CJS entry (no `module:` or `exports:` field) and the file is interop-CJS:

```js
Object.defineProperty(exports, '__esModule', { value: true });
exports.QRCode = X;
exports.default = X;
```

#### Bundle confirms it

| Version | Bundler | user-settings chunk | Renders |
| --- | --- | --- | --- |
| v5.1.1 | Vite 7 / Rollup | `import { Q as Kr } from "./index-…js"` | `jsx(Kr, …)` ✅ |
| v5.2.1 | Vite 8 / Rolldown | `oi = __toESM($qrLib(), 1)` | `jsx(oi.default, …)` ❌ |

#### Reproduced standalone

The bundler's `__toESM` helper plus a faked `react-qr-code` shape, in plain Node:

```js
const u = (n, r, a) => (a = n == null ? {} : Object.create(Object.getPrototypeOf(n)),
  l(r || !n || !n.__esModule ? Object.defineProperty(a, "default", {value: n, enumerable: true}) : a, n));

function QRCode() {}
const cjs = {};
Object.defineProperty(cjs, "__esModule", { value: true });
cjs.QRCode = QRCode;
cjs.default = QRCode;

const oi = u(cjs, 1);
typeof oi.default          // 'object'
oi.default === QRCode      // false
oi.default === cjs         // true  ← whole module object
```

#### The fix

Switch both call sites from default to named import. Rolldown does not emit `__toESM` for named CJS imports — the consumer just gets the module's exports namespace and reads `.QRCode` directly, which the lib already assigns to the same component. The lib's `.d.ts` only declares the default export, so a small module augmentation in `web/app/types.d.ts` exposes the existing-but-undeclared `QRCode` named export to TypeScript. No dependency bumps, no Vite downgrade.

After the change, the rebuilt `user-settings` chunk emits:

```js
oi = $qrLib()                       // no __toESM wrapper
jsx(oi.QRCode, { value: ... })      // accesses the actual component
```

#### Files

- `web/app/pages/UserSettings/components/TwoFA.tsx` — default → named import
- `web/app/routes/tools.qr-code-generator.tsx` — default → named import
- `web/app/types.d.ts` (new) — module augmentation declaring the `QRCode` named export

#### Local verification

All `npm run` checks the PR workflow runs are green on this branch:

```
> lint            Found 0 warnings and 0 errors.
> format:check    All matched files use the correct format.
> typecheck       (no output)
> knip            (no output)
> build           ✓ built in 1.39s
```

Manually verified the 2FA wizard renders the QR code and accepts the TOTP code on a self-hosted v5.2.1 + this patch.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal imports and TypeScript type definitions for QR code functionality to improve library compatibility and code stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->