### PR TITLE
Ask for current password on password change page

### DIFF
--- a/backend/apps/cloud/src/user/dto/update-user.dto.ts
+++ b/backend/apps/cloud/src/user/dto/update-user.dto.ts
@@ -10,6 +10,11 @@ export class UpdateUserProfileDTO {
   @ApiProperty({ example: 'your_password123' })
   password: string
 
+  @ApiProperty({ example: 'your_current_password123', required: false })
+  @IsString()
+  @IsOptional()
+  currentPassword?: string
+
   @ApiProperty({ example: 'week' })
   reportFrequency: string
 

--- a/backend/apps/cloud/src/user/user.controller.ts
+++ b/backend/apps/cloud/src/user/user.controller.ts
@@ -553,17 +553,30 @@ export class UserController {
     @CurrentUserId() id: string,
     @Req() request: Request,
   ): Promise<Partial<User>> {
-    this.logger.log({ userDTO, id }, 'PUT /user')
+    this.logger.log({ id }, 'PUT /user')
     const user = await this.userService.findOne({ where: { id } })
 
     const shouldUpdatePassword =
       !_isEmpty(userDTO.password) && _isString(userDTO.password)
 
     if (shouldUpdatePassword) {
-      // Validate new password
+      const currentPassword = userDTO.currentPassword
+
+      if (_isEmpty(currentPassword) || !_isString(currentPassword)) {
+        throw new BadRequestException('incorrectPassword')
+      }
+
+      const isPasswordValid = await this.authService.comparePassword(
+        currentPassword,
+        user.password,
+      )
+
+      if (!isPasswordValid) {
+        throw new BadRequestException('incorrectPassword')
+      }
+
       this.userService.validatePassword(userDTO.password)
 
-      // Hash new password
       userDTO.password = await this.authService.hashPassword(userDTO.password)
     }
 

--- a/backend/apps/community/src/user/dto/update-user.dto.ts
+++ b/backend/apps/community/src/user/dto/update-user.dto.ts
@@ -13,4 +13,7 @@ export class UpdateUserProfileDTO {
 
   @ApiProperty({ example: 'newStrongPassword123', required: false })
   password?: string
+
+  @ApiProperty({ example: 'currentStrongPassword123', required: false })
+  currentPassword?: string
 }

--- a/backend/apps/community/src/user/user.controller.ts
+++ b/backend/apps/community/src/user/user.controller.ts
@@ -341,7 +341,7 @@ export class UserController {
     @CurrentUserId() id: string,
     @Req() request: Request,
   ) {
-    this.logger.log({ userDTO, id }, 'PUT /user')
+    this.logger.log({ id }, 'PUT /user')
 
     const originalUser = await this.userService.findOne({ id })
 
@@ -349,11 +349,30 @@ export class UserController {
       throw new BadRequestException('User not found')
     }
 
-    try {
-      if (userDTO.password && typeof userDTO.password === 'string') {
-        this.userService.validatePassword(userDTO.password)
+    const newPassword = userDTO.password
+    const shouldUpdatePassword =
+      typeof newPassword === 'string' && newPassword.length > 0
 
-        const hashed = await this.authService.hashPassword(userDTO.password)
+    if (shouldUpdatePassword) {
+      if (!userDTO.currentPassword) {
+        throw new BadRequestException('incorrectPassword')
+      }
+
+      const isPasswordValid = await this.authService.comparePassword(
+        userDTO.currentPassword,
+        originalUser.password,
+      )
+
+      if (!isPasswordValid) {
+        throw new BadRequestException('incorrectPassword')
+      }
+    }
+
+    try {
+      if (shouldUpdatePassword) {
+        this.userService.validatePassword(newPassword)
+
+        const hashed = await this.authService.hashPassword(newPassword)
         await this.userService.update(id, { password: hashed })
 
         await Promise.all([

--- a/backend/apps/community/src/user/user.controller.ts
+++ b/backend/apps/community/src/user/user.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger'
 import _isEmpty from 'lodash/isEmpty'
+import _isString from 'lodash/isString'
 import _omit from 'lodash/omit'
 import _isNull from 'lodash/isNull'
 import _map from 'lodash/map'
@@ -354,12 +355,14 @@ export class UserController {
       typeof newPassword === 'string' && newPassword.length > 0
 
     if (shouldUpdatePassword) {
-      if (!userDTO.currentPassword) {
+      const currentPassword = userDTO.currentPassword
+
+      if (_isEmpty(currentPassword) || !_isString(currentPassword)) {
         throw new BadRequestException('incorrectPassword')
       }
 
       const isPasswordValid = await this.authService.comparePassword(
-        userDTO.currentPassword,
+        currentPassword,
         originalUser.password,
       )
 

--- a/web/app/pages/UserSettings/UserSettings.tsx
+++ b/web/app/pages/UserSettings/UserSettings.tsx
@@ -418,6 +418,7 @@ const UserSettings = () => {
 
   const lastHandledData = useRef<UserSettingsActionData | null>(null)
   const passwordChangedRef = useRef(false)
+  const pendingPasswordChangeRef = useRef(false)
   const pendingToggles = useRef<Map<string, boolean>>(new Map())
 
   const isSubmitting = fetcher.state === 'submitting'
@@ -437,6 +438,11 @@ const UserSettings = () => {
       const { intent, user: updatedUser, apiKey } = fetcher.data
 
       if (intent === 'update-profile' && updatedUser) {
+        if (pendingPasswordChangeRef.current) {
+          pendingPasswordChangeRef.current = false
+          passwordChangedRef.current = true
+        }
+
         mergeUser(updatedUser)
         toast.success(t('profileSettings.updated'))
 
@@ -472,7 +478,7 @@ const UserSettings = () => {
         toast.success(t('billing.subscriptionCancelledSuccess'))
         loadUser()
       }
-    } else if (fetcher.data?.error) {
+    } else if (fetcher.data?.error || fetcher.data?.fieldErrors) {
       setIsCancellingSubscription(false)
       if (pendingToggles.current.has('live-visitors')) {
         mergeUser({
@@ -488,6 +494,13 @@ const UserSettings = () => {
         })
         pendingToggles.current.delete('login-notifications')
       }
+      if (pendingPasswordChangeRef.current) {
+        pendingPasswordChangeRef.current = false
+        passwordChangedRef.current = false
+        setIsPasswordChangeModalOpened(false)
+      }
+      if (!fetcher.data.error) return
+
       const translated = t(`apiNotifications.${fetcher.data.error}`)
       toast.error(
         translated !== `apiNotifications.${fetcher.data.error}`
@@ -584,16 +597,19 @@ const UserSettings = () => {
     }
 
     if (form.email) setEmailBeenSubmitted(true)
-    if (form.password || form.repeat) setPasswordBeenSubmitted(true)
+    const hasPasswordUpdateInput = Boolean(
+      form.password || form.currentPassword,
+    )
+    if (hasPasswordUpdateInput || form.repeat) setPasswordBeenSubmitted(true)
 
     if (validated) {
       // User is about to change their password, let's warn him if
-      if (form.password && !force) {
+      if (hasPasswordUpdateInput && !force) {
         setIsPasswordChangeModalOpened(true)
         return
       }
 
-      submitProfileUpdate(undefined, false, Boolean(form.password))
+      submitProfileUpdate(undefined, false, hasPasswordUpdateInput)
     }
   }
 
@@ -1772,7 +1788,8 @@ const UserSettings = () => {
         }}
         onSubmit={() => {
           setIsPasswordChangeModalOpened(false)
-          passwordChangedRef.current = true
+          pendingPasswordChangeRef.current = Boolean(form.password)
+          passwordChangedRef.current = false
           submitProfileUpdate(undefined, true, true)
         }}
         closeText={t('common.cancel')}

--- a/web/app/pages/UserSettings/UserSettings.tsx
+++ b/web/app/pages/UserSettings/UserSettings.tsx
@@ -535,6 +535,7 @@ const UserSettings = () => {
   }, [form.currentPassword, form.email, form.password, form.repeat, t])
 
   const validated = _isEmpty(_keys(errors))
+  const hasPasswordUpdateInput = Boolean(form.password || form.repeat)
 
   const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event
@@ -568,7 +569,7 @@ const UserSettings = () => {
     const formData = new FormData()
     formData.set('intent', 'update-profile')
     formData.set('email', form.email || user?.email || '')
-    if (includePassword && form.currentPassword)
+    if (includePassword && hasPasswordUpdateInput && form.currentPassword)
       formData.set('currentPassword', form.currentPassword)
     if (includePassword && form.password)
       formData.set('password', form.password)
@@ -597,10 +598,7 @@ const UserSettings = () => {
     }
 
     if (form.email) setEmailBeenSubmitted(true)
-    const hasPasswordUpdateInput = Boolean(
-      form.password || form.currentPassword,
-    )
-    if (hasPasswordUpdateInput || form.repeat) setPasswordBeenSubmitted(true)
+    if (hasPasswordUpdateInput) setPasswordBeenSubmitted(true)
 
     if (validated) {
       // User is about to change their password, let's warn him if
@@ -622,9 +620,15 @@ const UserSettings = () => {
   }
 
   const handlePasswordSubmit = () => {
-    setPasswordBeenSubmitted(true)
+    if (hasPasswordUpdateInput) setPasswordBeenSubmitted(true)
 
-    if (errors.currentPassword || errors.password || errors.repeat) return
+    if (
+      !hasPasswordUpdateInput ||
+      errors.currentPassword ||
+      errors.password ||
+      errors.repeat
+    )
+      return
 
     setIsPasswordChangeModalOpened(true)
   }
@@ -1788,9 +1792,9 @@ const UserSettings = () => {
         }}
         onSubmit={() => {
           setIsPasswordChangeModalOpened(false)
-          pendingPasswordChangeRef.current = Boolean(form.password)
+          pendingPasswordChangeRef.current = hasPasswordUpdateInput
           passwordChangedRef.current = false
-          submitProfileUpdate(undefined, true, true)
+          submitProfileUpdate(undefined, true, hasPasswordUpdateInput)
         }}
         closeText={t('common.cancel')}
         submitText={t('common.continue')}

--- a/web/app/pages/UserSettings/UserSettings.tsx
+++ b/web/app/pages/UserSettings/UserSettings.tsx
@@ -236,6 +236,7 @@ const SettingsSection = ({
 )
 
 interface Form extends Partial<User> {
+  currentPassword: string
   repeat: string
   password: string
   email: string
@@ -385,6 +386,7 @@ const UserSettings = () => {
   }
   const [form, setForm] = useState<Form>(() => ({
     email: '',
+    currentPassword: '',
     password: '',
     repeat: '',
     timeFormat: user?.timeFormat || TimeFormat['12-hour'],
@@ -508,12 +510,16 @@ const UserSettings = () => {
       })
     }
 
+    if ((form.password || form.repeat) && !form.currentPassword) {
+      allErrors.currentPassword = t('profileSettings.currentPasswordRequired')
+    }
+
     if (form.password !== form.repeat) {
       allErrors.repeat = t('auth.common.noMatchError')
     }
 
     return allErrors
-  }, [form.email, form.password, form.repeat, t])
+  }, [form.currentPassword, form.email, form.password, form.repeat, t])
 
   const validated = _isEmpty(_keys(errors))
 
@@ -525,7 +531,11 @@ const UserSettings = () => {
       setEmailBeenSubmitted(false)
     }
 
-    if (target.name === 'password' || target.name === 'repeat') {
+    if (
+      target.name === 'currentPassword' ||
+      target.name === 'password' ||
+      target.name === 'repeat'
+    ) {
       setPasswordBeenSubmitted(false)
     }
 
@@ -538,14 +548,18 @@ const UserSettings = () => {
   const submitProfileUpdate = (
     additionalData?: Record<string, unknown>,
     skipValidation = false,
+    includePassword = false,
   ) => {
     if (!skipValidation && !validated) return
 
     const formData = new FormData()
     formData.set('intent', 'update-profile')
     formData.set('email', form.email || user?.email || '')
-    if (form.password) formData.set('password', form.password)
-    if (form.repeat) formData.set('repeat', form.repeat)
+    if (includePassword && form.currentPassword)
+      formData.set('currentPassword', form.currentPassword)
+    if (includePassword && form.password)
+      formData.set('password', form.password)
+    if (includePassword && form.repeat) formData.set('repeat', form.repeat)
     if (additionalData?.timezone)
       formData.set('timezone', additionalData.timezone as string)
     if (additionalData?.timeFormat || form.timeFormat) {
@@ -579,7 +593,7 @@ const UserSettings = () => {
         return
       }
 
-      submitProfileUpdate()
+      submitProfileUpdate(undefined, false, Boolean(form.password))
     }
   }
 
@@ -594,7 +608,7 @@ const UserSettings = () => {
   const handlePasswordSubmit = () => {
     setPasswordBeenSubmitted(true)
 
-    if (errors.password || errors.repeat) return
+    if (errors.currentPassword || errors.password || errors.repeat) return
 
     setIsPasswordChangeModalOpened(true)
   }
@@ -1063,6 +1077,17 @@ const UserSettings = () => {
                 >
                   <div className='max-w-md space-y-4'>
                     <Input
+                      name='currentPassword'
+                      type='password'
+                      label={t('profileSettings.currentPassword')}
+                      value={form.currentPassword}
+                      placeholder={t('auth.common.password')}
+                      onChange={handleInput}
+                      error={
+                        passwordBeenSubmitted ? errors.currentPassword : null
+                      }
+                    />
+                    <Input
                       name='password'
                       type='password'
                       label={t('profileSettings.newPassword')}
@@ -1084,7 +1109,9 @@ const UserSettings = () => {
                     <Button
                       size='lg'
                       onClick={handlePasswordSubmit}
-                      disabled={!form.password || !form.repeat}
+                      disabled={
+                        !form.currentPassword || !form.password || !form.repeat
+                      }
                     >
                       {t('profileSettings.updatePassword')}
                     </Button>
@@ -1746,7 +1773,7 @@ const UserSettings = () => {
         onSubmit={() => {
           setIsPasswordChangeModalOpened(false)
           passwordChangedRef.current = true
-          submitProfileUpdate(undefined, true)
+          submitProfileUpdate(undefined, true, true)
         }}
         closeText={t('common.cancel')}
         submitText={t('common.continue')}

--- a/web/app/routes/user-settings.tsx
+++ b/web/app/routes/user-settings.tsx
@@ -79,6 +79,7 @@ export interface UserSettingsActionData {
   intent?: string
   error?: string
   fieldErrors?: {
+    currentPassword?: string
     email?: string
     password?: string
     repeat?: string
@@ -102,6 +103,7 @@ export async function action({ request }: ActionFunctionArgs) {
   switch (intent) {
     case 'update-profile': {
       const email = formData.get('email')?.toString() || ''
+      const currentPassword = formData.get('currentPassword')?.toString() || ''
       const password = formData.get('password')?.toString() || ''
       const repeat = formData.get('repeat')?.toString() || ''
       const timezone = formData.get('timezone')?.toString()
@@ -115,6 +117,9 @@ export async function action({ request }: ActionFunctionArgs) {
       }
 
       if (password) {
+        if (!currentPassword) {
+          fieldErrors.currentPassword = 'Current password is required'
+        }
         if (!isValidPassword(password)) {
           fieldErrors.password = `Password must be at least ${MIN_PASSWORD_CHARS} characters`
         }
@@ -126,7 +131,12 @@ export async function action({ request }: ActionFunctionArgs) {
         }
       }
 
-      if (fieldErrors.email || fieldErrors.password || fieldErrors.repeat) {
+      if (
+        fieldErrors.currentPassword ||
+        fieldErrors.email ||
+        fieldErrors.password ||
+        fieldErrors.repeat
+      ) {
         return data<UserSettingsActionData>(
           { intent, fieldErrors },
           { status: 400 },
@@ -135,7 +145,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const updateData: Record<string, unknown> = {}
       if (email) updateData.email = email
-      if (password) updateData.password = password
+      if (password) {
+        updateData.currentPassword = currentPassword
+        updateData.password = password
+      }
       if (timezone) updateData.timezone = timezone
       if (timeFormat) updateData.timeFormat = timeFormat
       if (reportFrequency) updateData.reportFrequency = reportFrequency

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -846,6 +846,8 @@
     "accountDesc": "Manage your profile and general settings.",
     "passwordAuth": "Password & Authentication",
     "passwordAuthDesc": "Manage access to your account.",
+    "currentPassword": "Current password",
+    "currentPasswordRequired": "Current password is required",
     "newPassword": "New password",
     "repeatPassword": "New password (repeated)",
     "updatePassword": "Update password",


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password changes now require your current password; forms and flows enforce and submit it when updating your password. Server-side validation will verify the current password before applying a new one.

* **Behavioral Improvements**
  * Password-change confirmation modal revised: logout and session invalidation occur only after confirming the change. Error handling resets password UI state when appropriate.

* **Localization**
  * Added English strings for current-password label and required-message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Swetrix/swetrix/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->