### PR TITLE
feat: SEO analytics -> Add "Impressions by position" and "Organic positions" charts

### DIFF
--- a/backend/apps/cloud/src/project/gsc.service.ts
+++ b/backend/apps/cloud/src/project/gsc.service.ts
@@ -977,11 +977,23 @@ export class GSCService {
     const dimensionFilterGroups = this.getDimensionFilterGroups(filtersStr)
 
     try {
-      const rows = await this.queryGSC(gsc, from, to, {
-        dimensions: ['date', 'query'],
-        rowLimit: MAX_ROW_LIMIT,
-        dimensionFilterGroups,
-      })
+      const rows: GSCRow[] = []
+      let startRow = 0
+
+      while (true) {
+        const page = await this.queryGSC(gsc, from, to, {
+          dimensions: ['date', 'query'],
+          rowLimit: MAX_ROW_LIMIT,
+          startRow,
+          dimensionFilterGroups,
+        })
+
+        rows.push(...page)
+
+        if (page.length < MAX_ROW_LIMIT) break
+
+        startRow += MAX_ROW_LIMIT
+      }
 
       const impressionBuckets = initialImpressionPositionBuckets()
       const organicPositionsByDate = new Map<

--- a/backend/apps/cloud/src/project/gsc.service.ts
+++ b/backend/apps/cloud/src/project/gsc.service.ts
@@ -42,6 +42,79 @@ const MAX_BRANDED_PAGES = 10
 const MAX_FILTER_EXPRESSION_LENGTH = 500
 const MAX_FILTERS = 20
 
+const IMPRESSION_POSITION_BUCKETS = [
+  { key: 'pos1To3', label: '1-3' },
+  { key: 'pos4To10', label: '4-10' },
+  { key: 'pos11To20', label: '11-20' },
+  { key: 'pos21Plus', label: '21+' },
+] as const
+
+const ORGANIC_POSITION_BUCKET_KEYS = [
+  'pos1To3',
+  'pos4To10',
+  'pos11To20',
+  'pos21To50',
+  'pos51Plus',
+] as const
+
+type ImpressionPositionBucketKey =
+  (typeof IMPRESSION_POSITION_BUCKETS)[number]['key']
+type OrganicPositionBucketKey = (typeof ORGANIC_POSITION_BUCKET_KEYS)[number]
+type OrganicPositionSeriesEntry = { date: string } & Record<
+  OrganicPositionBucketKey,
+  number
+>
+
+const initialImpressionPositionBuckets = (): Record<
+  ImpressionPositionBucketKey,
+  number
+> => ({
+  pos1To3: 0,
+  pos4To10: 0,
+  pos11To20: 0,
+  pos21Plus: 0,
+})
+
+const initialOrganicPositionEntry = (
+  date: string,
+): OrganicPositionSeriesEntry => ({
+  date,
+  pos1To3: 0,
+  pos4To10: 0,
+  pos11To20: 0,
+  pos21To50: 0,
+  pos51Plus: 0,
+})
+
+const emptyPositionAnalytics = () => ({
+  impressionsByPosition: IMPRESSION_POSITION_BUCKETS.map(({ key, label }) => ({
+    key,
+    label,
+    impressions: 0,
+    percentage: 0,
+  })),
+  organicPositions: [] as OrganicPositionSeriesEntry[],
+})
+
+const getImpressionPositionBucketKey = (
+  position: number,
+): ImpressionPositionBucketKey => {
+  if (position <= 3) return 'pos1To3'
+  if (position <= 10) return 'pos4To10'
+  if (position <= 20) return 'pos11To20'
+  return 'pos21Plus'
+}
+
+const getOrganicPositionBucketKey = (
+  position: number,
+): OrganicPositionBucketKey => {
+  if (position <= 3) return 'pos1To3'
+  if (position <= 10) return 'pos4To10'
+  if (position <= 20) return 'pos11To20'
+  if (position <= 50) return 'pos21To50'
+  return 'pos51Plus'
+}
+
 type GSCRow = {
   keys: string[]
   clicks?: number
@@ -885,6 +958,100 @@ export class GSCService {
     }
   }
 
+  async getPositionAnalytics(
+    pid: string,
+    from: string,
+    to: string,
+    filtersStr?: string,
+    ctx?: GSCContext,
+  ): Promise<{
+    impressionsByPosition: {
+      key: ImpressionPositionBucketKey
+      label: string
+      impressions: number
+      percentage: number
+    }[]
+    organicPositions: OrganicPositionSeriesEntry[]
+  }> {
+    const gsc = ctx || (await this.getGSCContext(pid))
+    const dimensionFilterGroups = this.getDimensionFilterGroups(filtersStr)
+
+    try {
+      const rows = await this.queryGSC(gsc, from, to, {
+        dimensions: ['date', 'query'],
+        rowLimit: MAX_ROW_LIMIT,
+        dimensionFilterGroups,
+      })
+
+      const impressionBuckets = initialImpressionPositionBuckets()
+      const organicPositionsByDate = new Map<
+        string,
+        OrganicPositionSeriesEntry
+      >()
+      let totalImpressions = 0
+
+      for (const row of rows) {
+        const position = Number(row.position || 0)
+        const impressions = Math.round(row.impressions || 0)
+        const date = row.keys?.[0]
+
+        if (
+          !date ||
+          !Number.isFinite(position) ||
+          position <= 0 ||
+          impressions <= 0
+        ) {
+          continue
+        }
+
+        const impressionBucket = getImpressionPositionBucketKey(position)
+        impressionBuckets[impressionBucket] += impressions
+        totalImpressions += impressions
+
+        const organicBucket = getOrganicPositionBucketKey(position)
+        const organicEntry =
+          organicPositionsByDate.get(date) || initialOrganicPositionEntry(date)
+        organicEntry[organicBucket] += 1
+        organicPositionsByDate.set(date, organicEntry)
+      }
+
+      const organicPositions: OrganicPositionSeriesEntry[] = []
+      let cursor = dayjs(from).startOf('day')
+      const end = dayjs(to).startOf('day')
+
+      while (cursor.isBefore(end) || cursor.isSame(end, 'day')) {
+        const date = cursor.format('YYYY-MM-DD')
+        organicPositions.push(
+          organicPositionsByDate.get(date) || initialOrganicPositionEntry(date),
+        )
+        cursor = cursor.add(1, 'day')
+      }
+
+      return {
+        impressionsByPosition: IMPRESSION_POSITION_BUCKETS.map(
+          ({ key, label }) => ({
+            key,
+            label,
+            impressions: impressionBuckets[key],
+            percentage:
+              totalImpressions > 0
+                ? Number(
+                    ((impressionBuckets[key] / totalImpressions) * 100).toFixed(
+                      1,
+                    ),
+                  )
+                : 0,
+          }),
+        ),
+        organicPositions,
+      }
+    } catch {
+      throw new InternalServerErrorException(
+        'Failed to fetch position analytics from Search Console',
+      )
+    }
+  }
+
   async getDashboard(
     pid: string,
     from: string,
@@ -928,6 +1095,7 @@ export class GSCService {
       topCountries,
       topDevices,
       brandedTraffic,
+      positionAnalytics,
     ] = await Promise.all([
       this.getSummary(pid, from, to, filtersStr, ctx),
       this.getSummary(pid, prevFrom, prevTo, filtersStr, ctx).catch(() => null),
@@ -937,6 +1105,9 @@ export class GSCService {
       this.getTopCountries(pid, from, to, 50, 0, filtersStr, ctx),
       this.getTopDevices(pid, from, to, 50, 0, filtersStr, ctx),
       this.getBrandedTraffic(pid, from, to, filtersStr, ctx),
+      this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
+        emptyPositionAnalytics(),
+      ),
     ])
 
     return {
@@ -949,6 +1120,8 @@ export class GSCService {
       topCountries,
       topDevices,
       brandedTraffic,
+      impressionsByPosition: positionAnalytics.impressionsByPosition,
+      organicPositions: positionAnalytics.organicPositions,
     }
   }
 }

--- a/backend/apps/community/src/project/gsc.service.ts
+++ b/backend/apps/community/src/project/gsc.service.ts
@@ -1038,11 +1038,23 @@ export class GSCService {
     const dimensionFilterGroups = this.getDimensionFilterGroups(filtersStr)
 
     try {
-      const rows = await this.queryGSC(gsc, from, to, {
-        dimensions: ['date', 'query'],
-        rowLimit: MAX_ROW_LIMIT,
-        dimensionFilterGroups,
-      })
+      const rows: GSCRow[] = []
+      let startRow = 0
+
+      while (true) {
+        const page = await this.queryGSC(gsc, from, to, {
+          dimensions: ['date', 'query'],
+          rowLimit: MAX_ROW_LIMIT,
+          startRow,
+          dimensionFilterGroups,
+        })
+
+        rows.push(...page)
+
+        if (page.length < MAX_ROW_LIMIT) break
+
+        startRow += MAX_ROW_LIMIT
+      }
 
       const impressionBuckets = initialImpressionPositionBuckets()
       const organicPositionsByDate = new Map<

--- a/backend/apps/community/src/project/gsc.service.ts
+++ b/backend/apps/community/src/project/gsc.service.ts
@@ -42,6 +42,79 @@ const MAX_BRANDED_PAGES = 10
 const MAX_FILTER_EXPRESSION_LENGTH = 500
 const MAX_FILTERS = 20
 
+const IMPRESSION_POSITION_BUCKETS = [
+  { key: 'pos1To3', label: '1-3' },
+  { key: 'pos4To10', label: '4-10' },
+  { key: 'pos11To20', label: '11-20' },
+  { key: 'pos21Plus', label: '21+' },
+] as const
+
+const ORGANIC_POSITION_BUCKET_KEYS = [
+  'pos1To3',
+  'pos4To10',
+  'pos11To20',
+  'pos21To50',
+  'pos51Plus',
+] as const
+
+type ImpressionPositionBucketKey =
+  (typeof IMPRESSION_POSITION_BUCKETS)[number]['key']
+type OrganicPositionBucketKey = (typeof ORGANIC_POSITION_BUCKET_KEYS)[number]
+type OrganicPositionSeriesEntry = { date: string } & Record<
+  OrganicPositionBucketKey,
+  number
+>
+
+const initialImpressionPositionBuckets = (): Record<
+  ImpressionPositionBucketKey,
+  number
+> => ({
+  pos1To3: 0,
+  pos4To10: 0,
+  pos11To20: 0,
+  pos21Plus: 0,
+})
+
+const initialOrganicPositionEntry = (
+  date: string,
+): OrganicPositionSeriesEntry => ({
+  date,
+  pos1To3: 0,
+  pos4To10: 0,
+  pos11To20: 0,
+  pos21To50: 0,
+  pos51Plus: 0,
+})
+
+const emptyPositionAnalytics = () => ({
+  impressionsByPosition: IMPRESSION_POSITION_BUCKETS.map(({ key, label }) => ({
+    key,
+    label,
+    impressions: 0,
+    percentage: 0,
+  })),
+  organicPositions: [] as OrganicPositionSeriesEntry[],
+})
+
+const getImpressionPositionBucketKey = (
+  position: number,
+): ImpressionPositionBucketKey => {
+  if (position <= 3) return 'pos1To3'
+  if (position <= 10) return 'pos4To10'
+  if (position <= 20) return 'pos11To20'
+  return 'pos21Plus'
+}
+
+const getOrganicPositionBucketKey = (
+  position: number,
+): OrganicPositionBucketKey => {
+  if (position <= 3) return 'pos1To3'
+  if (position <= 10) return 'pos4To10'
+  if (position <= 20) return 'pos11To20'
+  if (position <= 50) return 'pos21To50'
+  return 'pos51Plus'
+}
+
 type GSCRow = {
   keys: string[]
   clicks?: number
@@ -946,6 +1019,100 @@ export class GSCService {
     }
   }
 
+  async getPositionAnalytics(
+    pid: string,
+    from: string,
+    to: string,
+    filtersStr?: string,
+    ctx?: GSCContext,
+  ): Promise<{
+    impressionsByPosition: {
+      key: ImpressionPositionBucketKey
+      label: string
+      impressions: number
+      percentage: number
+    }[]
+    organicPositions: OrganicPositionSeriesEntry[]
+  }> {
+    const gsc = ctx || (await this.getGSCContext(pid))
+    const dimensionFilterGroups = this.getDimensionFilterGroups(filtersStr)
+
+    try {
+      const rows = await this.queryGSC(gsc, from, to, {
+        dimensions: ['date', 'query'],
+        rowLimit: MAX_ROW_LIMIT,
+        dimensionFilterGroups,
+      })
+
+      const impressionBuckets = initialImpressionPositionBuckets()
+      const organicPositionsByDate = new Map<
+        string,
+        OrganicPositionSeriesEntry
+      >()
+      let totalImpressions = 0
+
+      for (const row of rows) {
+        const position = Number(row.position || 0)
+        const impressions = Math.round(row.impressions || 0)
+        const date = row.keys?.[0]
+
+        if (
+          !date ||
+          !Number.isFinite(position) ||
+          position <= 0 ||
+          impressions <= 0
+        ) {
+          continue
+        }
+
+        const impressionBucket = getImpressionPositionBucketKey(position)
+        impressionBuckets[impressionBucket] += impressions
+        totalImpressions += impressions
+
+        const organicBucket = getOrganicPositionBucketKey(position)
+        const organicEntry =
+          organicPositionsByDate.get(date) || initialOrganicPositionEntry(date)
+        organicEntry[organicBucket] += 1
+        organicPositionsByDate.set(date, organicEntry)
+      }
+
+      const organicPositions: OrganicPositionSeriesEntry[] = []
+      let cursor = dayjs(from).startOf('day')
+      const end = dayjs(to).startOf('day')
+
+      while (cursor.isBefore(end) || cursor.isSame(end, 'day')) {
+        const date = cursor.format('YYYY-MM-DD')
+        organicPositions.push(
+          organicPositionsByDate.get(date) || initialOrganicPositionEntry(date),
+        )
+        cursor = cursor.add(1, 'day')
+      }
+
+      return {
+        impressionsByPosition: IMPRESSION_POSITION_BUCKETS.map(
+          ({ key, label }) => ({
+            key,
+            label,
+            impressions: impressionBuckets[key],
+            percentage:
+              totalImpressions > 0
+                ? Number(
+                    ((impressionBuckets[key] / totalImpressions) * 100).toFixed(
+                      1,
+                    ),
+                  )
+                : 0,
+          }),
+        ),
+        organicPositions,
+      }
+    } catch {
+      throw new InternalServerErrorException(
+        'Failed to fetch position analytics from Search Console',
+      )
+    }
+  }
+
   async getDashboard(
     pid: string,
     from: string,
@@ -993,6 +1160,7 @@ export class GSCService {
       topCountries,
       topDevices,
       brandedTraffic,
+      positionAnalytics,
     ] = await Promise.all([
       this.getSummary(pid, from, to, filtersStr, ctx),
       this.getSummary(pid, prevFrom, prevTo, filtersStr, ctx).catch(() => null),
@@ -1002,6 +1170,9 @@ export class GSCService {
       this.getTopCountries(pid, from, to, 50, 0, filtersStr, ctx),
       this.getTopDevices(pid, from, to, 50, 0, filtersStr, ctx),
       this.getBrandedTraffic(pid, from, to, filtersStr, ctx),
+      this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
+        emptyPositionAnalytics(),
+      ),
     ])
 
     return {
@@ -1014,6 +1185,8 @@ export class GSCService {
       topCountries,
       topDevices,
       brandedTraffic,
+      impressionsByPosition: positionAnalytics.impressionsByPosition,
+      organicPositions: positionAnalytics.organicPositions,
     }
   }
 }

--- a/docs/content/docs/analytics-dashboard/seo.mdx
+++ b/docs/content/docs/analytics-dashboard/seo.mdx
@@ -3,7 +3,7 @@ title: SEO
 slug: /analytics-dashboard/seo
 ---
 
-The SEO dashboard gives you a complete view of your website's search engine performance, powered by your [Google Search Console](/integrations/google-search-console) integration. It combines GSC data with your referral analytics to show search queries, top pages, branded traffic, and optimisation opportunities — all in one place.
+The SEO dashboard gives you a complete view of your website's search engine performance, powered by your [Google Search Console](/integrations/google-search-console) integration. It combines GSC data with your referral analytics to show search queries, top pages, ranking positions, branded traffic, and optimisation opportunities — all in one place.
 
 <img alt="SEO Dashboard" src="/docs/img/analytics-dashboard/seo.png" />
 
@@ -34,6 +34,8 @@ Below the metrics, an area chart visualises your search performance over time. Y
 
 When multiple metric types are shown together, the chart uses dual Y-axes for readability.
 
+You can also enable **Compare to previous period** from the date selector to overlay the previous period on the trend chart and update the metric comparison badges.
+
 ## Search Engines & AI Referrals
 
 Two compact panels show your top traffic sources from search:
@@ -59,6 +61,13 @@ Swetrix automatically detects brand keywords from your project name and website 
 1. Go to **Settings** > **General**.
 2. Find the **Brand keywords** field.
 3. Enter comma-separated keywords (e.g., `swetrix, swetrix analytics`).
+
+## Position Analytics
+
+Two panels help you understand how your organic visibility is distributed across ranking positions:
+
+- **Impressions by Position** — A bar chart that groups impressions by average position buckets: 1–3, 4–10, 11–20, and 21+. This shows whether most impressions come from high-ranking keywords or from queries that still have room to climb.
+- **Organic Positions** — A cumulative chart showing how many ranking queries you have in each position range over time: 1–3, 4–10, 11–20, 21–50, and 51+. Use it to spot whether your keyword footprint is moving into stronger positions or drifting down.
 
 ## Top Pages & Top Queries
 

--- a/web/app/api/api.server.ts
+++ b/web/app/api/api.server.ts
@@ -2664,6 +2664,31 @@ interface GSCTopDeviceEntry {
   position: number
 }
 
+type GSCImpressionPositionBucketKey =
+  | 'pos1To3'
+  | 'pos4To10'
+  | 'pos11To20'
+  | 'pos21Plus'
+
+type GSCOrganicPositionBucketKey =
+  | 'pos1To3'
+  | 'pos4To10'
+  | 'pos11To20'
+  | 'pos21To50'
+  | 'pos51Plus'
+
+interface GSCImpressionsByPositionEntry {
+  key: GSCImpressionPositionBucketKey
+  label: string
+  impressions: number
+  percentage: number
+}
+
+type GSCOrganicPositionEntry = { date: string } & Record<
+  GSCOrganicPositionBucketKey,
+  number
+>
+
 export interface GSCDashboardResponse {
   notConnected?: boolean
   noProperty?: boolean
@@ -2688,6 +2713,8 @@ export interface GSCDashboardResponse {
     branded: number
     nonBranded: number
   }
+  impressionsByPosition?: GSCImpressionsByPositionEntry[]
+  organicPositions?: GSCOrganicPositionEntry[]
 }
 
 export async function getGSCDashboardServer(

--- a/web/app/hooks/useAnalyticsProxy.ts
+++ b/web/app/hooks/useAnalyticsProxy.ts
@@ -862,7 +862,13 @@ export function useGSCDashboardProxy() {
     [],
   )
 
-  return { fetchDashboard, data, error, isLoading }
+  const resetData = useCallback(() => {
+    setData(null)
+    setError(null)
+    setIsLoading(false)
+  }, [])
+
+  return { fetchDashboard, data, error, isLoading, resetData }
 }
 
 export function useRevenueProxy() {

--- a/web/app/pages/Project/tabs/SEO/SEOView.tsx
+++ b/web/app/pages/Project/tabs/SEO/SEOView.tsx
@@ -8,6 +8,8 @@ import {
   MagnifyingGlassIcon,
   MapPinIcon,
   TargetIcon,
+  ChartBarIcon,
+  TrendUpIcon,
 } from '@phosphor-icons/react'
 import _isEmpty from 'lodash/isEmpty'
 import _round from 'lodash/round'
@@ -66,12 +68,15 @@ import {
   type SEOMetricKey,
   aggregateDateSeries,
   getGSCCompatibleFilters,
+  hasOrganicPositionData,
 } from './seo-utils'
 import type { QuadrantData } from './seo-chart-options'
 import {
   buildMainChartOptions,
   buildQuadrantChartOptions,
   buildDonutChartOptions,
+  buildImpressionsByPositionChartOptions,
+  buildOrganicPositionsChartOptions,
 } from './seo-chart-options'
 
 interface SEOViewProps {
@@ -94,10 +99,16 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     periodPairs,
     filters,
     getFilterLink,
+    isActiveCompare,
   } = useViewProjectContext()
   const { seoRefreshTrigger } = useRefreshTriggers()
   const { fetchDashboard, data, isLoading } = useGSCDashboardProxy()
-  const [searchParams] = useSearchParams()
+  const {
+    fetchDashboard: fetchCompareDashboard,
+    data: compareData,
+    resetData: resetCompareData,
+  } = useGSCDashboardProxy()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const [activeMetrics, setActiveMetrics] = useState<
     Record<SEOMetricKey, boolean>
@@ -123,6 +134,45 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
         }),
     [periodPairs],
   )
+
+  const activeSeoPeriod = useMemo(
+    () => seoPeriodPairs.find((p) => p.period === period),
+    [seoPeriodPairs, period],
+  )
+
+  const urlTimeBucket = searchParams.get('timeBucket') as TimeBucket | null
+
+  const seoTimeBucket = useMemo<TimeBucket>(() => {
+    if (!urlTimeBucket && activeSeoPeriod?.tbs.includes('day')) {
+      return 'day'
+    }
+
+    if (activeSeoPeriod?.tbs.includes(timeBucket as TimeBucket)) {
+      return timeBucket as TimeBucket
+    }
+
+    return activeSeoPeriod?.tbs[0] || (timeBucket as TimeBucket)
+  }, [activeSeoPeriod, timeBucket, urlTimeBucket])
+
+  useEffect(() => {
+    if (
+      urlTimeBucket ||
+      !activeSeoPeriod?.tbs.includes('day') ||
+      timeBucket === 'day'
+    ) {
+      return
+    }
+
+    const newSearchParams = new URLSearchParams(searchParams.toString())
+    newSearchParams.set('timeBucket', 'day')
+    setSearchParams(newSearchParams, { replace: true })
+  }, [
+    activeSeoPeriod,
+    searchParams,
+    setSearchParams,
+    timeBucket,
+    urlTimeBucket,
+  ])
 
   const metricItems = useMemo(
     () => [
@@ -193,25 +243,52 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
 
   const from = searchParams.get('from') || undefined
   const to = searchParams.get('to') || undefined
+  const compareEnabled = searchParams.get('compare') === 'true'
+  const compareFrom = searchParams.get('compareFrom') || undefined
+  const compareTo = searchParams.get('compareTo') || undefined
 
   const loadData = useCallback(async () => {
-    await fetchDashboard(projectId, {
+    const params = {
       period,
       from,
       to,
       timezone,
-      timeBucket,
+      timeBucket: seoTimeBucket,
       filters: gscFilters,
-    })
+    }
+
+    const currentPromise = fetchDashboard(projectId, params)
+
+    if (isActiveCompare && compareEnabled && compareFrom && compareTo) {
+      await Promise.all([
+        currentPromise,
+        fetchCompareDashboard(projectId, {
+          ...params,
+          period: 'custom',
+          from: compareFrom,
+          to: compareTo,
+        }),
+      ])
+      return
+    }
+
+    resetCompareData()
+    await currentPromise
   }, [
     fetchDashboard,
+    fetchCompareDashboard,
+    resetCompareData,
     projectId,
     period,
     from,
     to,
+    compareEnabled,
+    compareFrom,
+    compareTo,
     timezone,
-    timeBucket,
+    seoTimeBucket,
     gscFilters,
+    isActiveCompare,
   ])
 
   useEffect(() => {
@@ -249,8 +326,13 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
   )
 
   const aggregatedSeries = useMemo(
-    () => aggregateDateSeries(data?.dateSeries || [], timeBucket),
-    [data?.dateSeries, timeBucket],
+    () => aggregateDateSeries(data?.dateSeries || [], seoTimeBucket),
+    [data?.dateSeries, seoTimeBucket],
+  )
+
+  const aggregatedCompareSeries = useMemo(
+    () => aggregateDateSeries(compareData?.dateSeries || [], seoTimeBucket),
+    [compareData?.dateSeries, seoTimeBucket],
   )
 
   const topPagesAsEntries: Entry[] = useMemo(
@@ -335,6 +417,37 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     [brandedTraffic, t, theme],
   )
 
+  const impressionsByPosition = useMemo(
+    () => data?.impressionsByPosition || [],
+    [data?.impressionsByPosition],
+  )
+
+  const organicPositions = useMemo(
+    () => data?.organicPositions || [],
+    [data?.organicPositions],
+  )
+
+  const hasImpressionsByPositionData = useMemo(
+    () => impressionsByPosition.some((bucket) => bucket.impressions > 0),
+    [impressionsByPosition],
+  )
+
+  const hasOrganicPositions = useMemo(
+    () => hasOrganicPositionData(organicPositions),
+    [organicPositions],
+  )
+
+  const impressionsByPositionOptions = useMemo(
+    () =>
+      buildImpressionsByPositionChartOptions(impressionsByPosition, theme, t),
+    [impressionsByPosition, theme, t],
+  )
+
+  const organicPositionsOptions = useMemo(
+    () => buildOrganicPositionsChartOptions(organicPositions, theme, t),
+    [organicPositions, theme, t],
+  )
+
   const countryRowMapper = useCallback(
     (entry: any) => <CCRow cc={entry.name} language={language} />,
     [language],
@@ -367,9 +480,31 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     return buildQuadrantChartOptions(quadrantData, avgCtr, avgPos, theme, t)
   }, [quadrantData, data?.summary, theme, t])
 
+  const comparisonSummary =
+    isActiveCompare && compareEnabled
+      ? compareData?.summary
+      : data?.previousSummary
+
   const chartOptions = useMemo(
-    () => buildMainChartOptions(aggregatedSeries, activeMetrics, timeBucket, t),
-    [aggregatedSeries, activeMetrics, timeBucket, t],
+    () =>
+      buildMainChartOptions(
+        aggregatedSeries,
+        activeMetrics,
+        seoTimeBucket,
+        t,
+        isActiveCompare && compareEnabled && aggregatedCompareSeries.length
+          ? aggregatedCompareSeries
+          : undefined,
+      ),
+    [
+      aggregatedSeries,
+      activeMetrics,
+      seoTimeBucket,
+      t,
+      isActiveCompare,
+      compareEnabled,
+      aggregatedCompareSeries,
+    ],
   )
 
   const detailsExtraColumns = useMemo(
@@ -638,8 +773,8 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
             label={t('project.seo.clicks')}
             value={data?.summary?.clicks ?? 0}
             change={
-              data?.previousSummary
-                ? (data.summary?.clicks ?? 0) - data.previousSummary.clicks
+              comparisonSummary
+                ? (data?.summary?.clicks ?? 0) - comparisonSummary.clicks
                 : undefined
             }
             goodChangeDirection='down'
@@ -651,9 +786,9 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
             label={t('project.seo.impressions')}
             value={data?.summary?.impressions ?? 0}
             change={
-              data?.previousSummary
-                ? (data.summary?.impressions ?? 0) -
-                  data.previousSummary.impressions
+              comparisonSummary
+                ? (data?.summary?.impressions ?? 0) -
+                  comparisonSummary.impressions
                 : undefined
             }
             goodChangeDirection='down'
@@ -665,8 +800,8 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
             label={t('project.seo.avgCTR')}
             value={_round(data?.summary?.ctr ?? 0, 2)}
             change={
-              data?.previousSummary
-                ? _round((data.summary?.ctr ?? 0) - data.previousSummary.ctr, 2)
+              comparisonSummary
+                ? _round((data?.summary?.ctr ?? 0) - comparisonSummary.ctr, 2)
                 : undefined
             }
             type='percent'
@@ -679,10 +814,9 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
             label={t('project.seo.avgPosition')}
             value={_round(data?.summary?.position ?? 0, 1)}
             change={
-              data?.previousSummary
+              comparisonSummary
                 ? _round(
-                    (data.summary?.position ?? 0) -
-                      data.previousSummary.position,
+                    (data?.summary?.position ?? 0) - comparisonSummary.position,
                     1,
                   )
                 : undefined
@@ -698,7 +832,13 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
             chartId='seo-main-chart'
             options={chartOptions}
             className='h-80 [&_svg]:overflow-visible!'
-            deps={[aggregatedSeries, activeMetrics, timeBucket, timeFormat]}
+            deps={[
+              aggregatedSeries,
+              aggregatedCompareSeries,
+              activeMetrics,
+              seoTimeBucket,
+              timeFormat,
+            ]}
           />
         ) : null}
       </div>
@@ -733,6 +873,42 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
             <PanelEmptyState message={t('project.seo.noBrandData')} />
           )}
         </div>
+      </div>
+
+      <div className='mt-3 grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.35fr)]'>
+        <PanelContainer
+          name={t('project.seo.impressionsByPosition')}
+          icon={<ChartBarIcon className='size-5' />}
+          type='impressionsByPosition'
+          contentClassName='relative flex min-h-[21rem] flex-col overflow-hidden'
+        >
+          {hasImpressionsByPositionData ? (
+            <BillboardChart
+              options={impressionsByPositionOptions}
+              className='seo-impressions-position-chart min-h-72 flex-1 [&_svg]:overflow-visible!'
+              deps={[impressionsByPosition, theme, t]}
+            />
+          ) : (
+            <PanelEmptyState message={t('project.seo.noPositionData')} />
+          )}
+        </PanelContainer>
+
+        <PanelContainer
+          name={t('project.seo.organicPositions')}
+          icon={<TrendUpIcon className='size-5' />}
+          type='organicPositions'
+          contentClassName='relative flex min-h-[21rem] flex-col overflow-hidden'
+        >
+          {hasOrganicPositions ? (
+            <BillboardChart
+              options={organicPositionsOptions}
+              className='min-h-80 flex-1 [&_svg]:overflow-visible!'
+              deps={[organicPositions, theme, t]}
+            />
+          ) : (
+            <PanelEmptyState message={t('project.seo.noPositionData')} />
+          )}
+        </PanelContainer>
       </div>
 
       <div className='mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2'>

--- a/web/app/pages/Project/tabs/SEO/SEOView.tsx
+++ b/web/app/pages/Project/tabs/SEO/SEOView.tsx
@@ -260,6 +260,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     const currentPromise = fetchDashboard(projectId, params)
 
     if (isActiveCompare && compareEnabled && compareFrom && compareTo) {
+      resetCompareData()
       await Promise.all([
         currentPromise,
         fetchCompareDashboard(projectId, {

--- a/web/app/pages/Project/tabs/SEO/seo-chart-options.ts
+++ b/web/app/pages/Project/tabs/SEO/seo-chart-options.ts
@@ -128,11 +128,12 @@ export function buildMainChartOptions(
     year: '%Y',
   }
   const tickFormat = tickFormatMap[timeBucket] || '%b %d'
+  const xFormat = timeBucket === 'hour' ? '%Y-%m-%d %H:%M:%S' : '%Y-%m-%d'
 
   return {
     data: {
       x: 'x',
-      xFormat: timeBucket === 'hour' ? '%Y-%m-%d %H:%M:%S' : '%Y-%m-%d',
+      xFormat,
       columns,
       types,
       axes,
@@ -219,7 +220,7 @@ export function buildMainChartOptions(
           ? compareSeries?.[firstIndex]?.date
           : null
         const parsedCompareDate = compareDate
-          ? d3.timeParse('%Y-%m-%d')(compareDate)
+          ? d3.timeParse(xFormat)(compareDate)
           : null
         const compareHeaderLabel = parsedCompareDate
           ? d3.timeFormat(tooltipFmt)(parsedCompareDate)

--- a/web/app/pages/Project/tabs/SEO/seo-chart-options.ts
+++ b/web/app/pages/Project/tabs/SEO/seo-chart-options.ts
@@ -1,17 +1,56 @@
 import type { ChartOptions } from 'billboard.js'
-import { area, donut, scatter } from 'billboard.js'
+import { area, bar, donut, line, scatter } from 'billboard.js'
 import * as d3 from 'd3'
 import _round from 'lodash/round'
 import type { TFunction } from 'i18next'
 
 import { escapeHtml, nFormatter } from '~/utils/generic'
-import type { DateSeriesEntry, SEOMetricKey } from './seo-utils'
+import {
+  SEO_IMPRESSION_POSITION_BUCKETS,
+  SEO_METRICS,
+  SEO_ORGANIC_POSITION_BUCKETS,
+  type DateSeriesEntry,
+  type ImpressionsByPositionEntry,
+  type OrganicPositionEntry,
+  type SEOMetricKey,
+} from './seo-utils'
+
+const SEO_MAIN_METRIC_COLORS: Record<SEOMetricKey, string> = {
+  clicks: '#2563eb',
+  impressions: '#7c3aed',
+  position: '#d97706',
+  ctr: '#0d9488',
+}
+
+const SEO_MAIN_METRIC_COMPARE_COLORS: Record<SEOMetricKey, string> = {
+  clicks: 'rgba(37, 99, 235, 0.4)',
+  impressions: 'rgba(124, 58, 237, 0.4)',
+  position: 'rgba(217, 119, 6, 0.4)',
+  ctr: 'rgba(13, 148, 136, 0.4)',
+}
+
+const formatSEOMetricValue = (metric: SEOMetricKey, value: number) => {
+  if (metric === SEO_METRICS.ctr) {
+    return `${Number(value).toFixed(1)}%`
+  }
+
+  if (metric === SEO_METRICS.position) {
+    return Number(value).toFixed(1)
+  }
+
+  return nFormatter(value, 1)
+}
+
+const getSEOMetricValue = (entry: DateSeriesEntry, metric: SEOMetricKey) => {
+  return entry[metric] ?? 0
+}
 
 export function buildMainChartOptions(
   series: DateSeriesEntry[],
   activeMetrics: Record<SEOMetricKey, boolean>,
   timeBucket: string,
   t: TFunction,
+  compareSeries?: DateSeriesEntry[],
 ): ChartOptions {
   if (!series.length) return {}
 
@@ -19,43 +58,66 @@ export function buildMainChartOptions(
   const columns: any[] = [['x', ...dates]]
   const colors: Record<string, string> = {}
   const axes: Record<string, string> = {}
+  const names: Record<string, string> = {}
+  const types: Record<string, any> = {}
+  const compareIds: string[] = []
   let needsY2 = false
-
-  if (activeMetrics.clicks) {
-    const label = t('project.seo.clicks')
-    columns.push([label, ...series.map((d) => d.clicks)])
-    colors[label] = '#3b82f6'
+  const hasCompareSeries = !!compareSeries?.length
+  const metricLabels: Record<SEOMetricKey, string> = {
+    clicks: t('project.seo.clicks'),
+    impressions: t('project.seo.impressions'),
+    position: t('project.seo.avgPosition'),
+    ctr: t('project.seo.avgCTR'),
   }
 
-  if (activeMetrics.impressions) {
-    const label = t('project.seo.impressions')
-    columns.push([label, ...series.map((d) => d.impressions)])
-    colors[label] = '#5b21b6'
-    if (activeMetrics.clicks) {
-      axes[label] = 'y2'
+  const metricUsesSecondaryAxis = (metric: SEOMetricKey) => {
+    if (metric === SEO_METRICS.impressions) {
+      return activeMetrics.clicks
+    }
+
+    if (metric === SEO_METRICS.position || metric === SEO_METRICS.ctr) {
+      return activeMetrics.clicks || activeMetrics.impressions
+    }
+
+    return false
+  }
+
+  const metricKeys = Object.keys(SEO_METRICS) as SEOMetricKey[]
+
+  metricKeys.forEach((metric: SEOMetricKey) => {
+    if (!activeMetrics[metric]) return
+
+    const compareId = `${metric}Compare`
+    const usesY2 = metricUsesSecondaryAxis(metric)
+
+    columns.push([metric, ...series.map((d) => getSEOMetricValue(d, metric))])
+    colors[metric] = SEO_MAIN_METRIC_COLORS[metric]
+    names[metric] = metricLabels[metric]
+    types[metric] = area()
+
+    if (usesY2) {
+      axes[metric] = 'y2'
       needsY2 = true
     }
-  }
 
-  if (activeMetrics.position) {
-    const label = t('project.seo.avgPosition')
-    columns.push([label, ...series.map((d) => d.position)])
-    colors[label] = '#d97706'
-    if (activeMetrics.clicks || activeMetrics.impressions) {
-      axes[label] = 'y2'
-      needsY2 = true
-    }
-  }
+    if (hasCompareSeries) {
+      columns.push([
+        compareId,
+        ...dates.map((_, index) => {
+          const entry = compareSeries?.[index]
+          return entry ? getSEOMetricValue(entry, metric) : null
+        }),
+      ])
+      colors[compareId] = SEO_MAIN_METRIC_COMPARE_COLORS[metric]
+      names[compareId] = metricLabels[metric]
+      types[compareId] = line()
+      compareIds.push(compareId)
 
-  if (activeMetrics.ctr) {
-    const label = t('project.seo.avgCTR')
-    columns.push([label, ...series.map((d) => d.ctr)])
-    colors[label] = '#0d9488'
-    if (activeMetrics.clicks || activeMetrics.impressions) {
-      axes[label] = 'y2'
-      needsY2 = true
+      if (usesY2) {
+        axes[compareId] = 'y2'
+      }
     }
-  }
+  })
 
   const tickFormatMap: Record<string, string> = {
     hour: '%b %d %H:%M',
@@ -72,9 +134,10 @@ export function buildMainChartOptions(
       x: 'x',
       xFormat: timeBucket === 'hour' ? '%Y-%m-%d %H:%M:%S' : '%Y-%m-%d',
       columns,
-      type: area(),
+      types,
       axes,
       colors,
+      names,
     },
     area: {
       linearGradient: true,
@@ -135,9 +198,12 @@ export function buildMainChartOptions(
           r: 3,
         },
       },
+      hide: compareIds,
     },
     tooltip: {
       contents: (items, _defaultTitleFormat, _defaultValueFormat, color) => {
+        if (!items.length) return ''
+
         const tooltipFormatMap: Record<string, string> = {
           hour: '%b %d, %Y %H:%M',
           day: '%a, %d %b',
@@ -147,16 +213,25 @@ export function buildMainChartOptions(
           year: '%Y',
         }
         const tooltipFmt = tooltipFormatMap[timeBucket] || '%b %d, %Y'
+        const firstIndex = items[0].index ?? 0
         const headerLabel = d3.timeFormat(tooltipFmt)(items[0].x)
-        return `<ul class='bg-gray-50 dark:text-gray-50 dark:bg-slate-900 rounded-md ring-1 ring-black/10 px-2 py-1 text-xs md:text-sm max-h-[250px] md:max-h-[350px] overflow-y-auto shadow-md z-50'>
-            <li class='font-semibold pb-1 mb-1 border-b border-gray-200 dark:border-slate-800 sticky top-0 bg-gray-50 dark:bg-slate-900'>${headerLabel}</li>
-            ${items
+        const compareDate = hasCompareSeries
+          ? compareSeries?.[firstIndex]?.date
+          : null
+        const parsedCompareDate = compareDate
+          ? d3.timeParse('%Y-%m-%d')(compareDate)
+          : null
+        const compareHeaderLabel = parsedCompareDate
+          ? d3.timeFormat(tooltipFmt)(parsedCompareDate)
+          : ''
+        const currentItems = items.filter(
+          (el: any) => !String(el.id).endsWith('Compare'),
+        )
+        const currentSection = `<li class='font-semibold pb-1 mb-1 border-b border-gray-200 dark:border-slate-800 sticky top-0 bg-gray-50 dark:bg-slate-900'>${headerLabel}</li>
+            ${currentItems
               .map((el: any) => {
-                const isCtr = el.name === t('project.seo.avgCTR')
-                const isPos = el.name === t('project.seo.avgPosition')
-                let formatted = nFormatter(el.value, 1)
-                if (isCtr) formatted = `${Number(el.value).toFixed(1)}%`
-                else if (isPos) formatted = Number(el.value).toFixed(1)
+                const metric = el.id as SEOMetricKey
+                const formatted = formatSEOMetricValue(metric, el.value)
 
                 return `
             <li class='flex justify-between items-center py-px leading-snug'>
@@ -167,11 +242,263 @@ export function buildMainChartOptions(
               <span class='font-mono whitespace-nowrap'>${formatted}</span>
             </li>`
               })
-              .join('')}
+              .join('')}`
+        const compareSection = compareHeaderLabel
+          ? `<li class='font-semibold pb-1 mb-1 mt-3 pt-2 border-t border-b border-gray-200 dark:border-slate-800'>${compareHeaderLabel}</li>
+            ${currentItems
+              .map((el: any) => {
+                const metric = el.id as SEOMetricKey
+                const compareValue = compareSeries?.[el.index]?.[metric]
+                if (compareValue == null) return ''
+
+                return `
+            <li class='flex justify-between items-center py-px leading-snug'>
+              <div class='flex items-center min-w-0 mr-4'>
+                <div class='w-2.5 h-2.5 rounded-xs mr-1.5 shrink-0 opacity-60' style=background-color:${color(el.id)}></div>
+                <span class="truncate opacity-75">${el.name}</span>
+              </div>
+              <span class='font-mono whitespace-nowrap opacity-75'>${formatSEOMetricValue(metric, compareValue)}</span>
+            </li>`
+              })
+              .join('')}`
+          : ''
+
+        return `<ul class='bg-gray-50 dark:text-gray-50 dark:bg-slate-900 rounded-md ring-1 ring-black/10 px-2 py-1 text-xs md:text-sm max-h-[250px] md:max-h-[350px] overflow-y-auto shadow-md z-50'>
+            ${currentSection}
+            ${compareSection}
           </ul>`
       },
     },
     padding: { right: needsY2 ? 20 : undefined },
+  }
+}
+
+export function buildImpressionsByPositionChartOptions(
+  buckets: ImpressionsByPositionEntry[],
+  theme: string,
+  t: TFunction,
+): ChartOptions {
+  const bucketMap = new Map(buckets.map((bucket) => [bucket.key, bucket]))
+  const labels = SEO_IMPRESSION_POSITION_BUCKETS.map(({ label }) => label)
+  const values = SEO_IMPRESSION_POSITION_BUCKETS.map(
+    ({ key }) => bucketMap.get(key)?.impressions ?? 0,
+  )
+  const seriesLabel = t('project.seo.impressions')
+  const axisLabels = SEO_IMPRESSION_POSITION_BUCKETS.map(({ key, label }) => {
+    const bucket = bucketMap.get(key)
+    return `${label}\n${nFormatter(bucket?.impressions ?? 0, 1)} (${(bucket?.percentage ?? 0).toFixed(1)}%)`
+  })
+  const colors = SEO_IMPRESSION_POSITION_BUCKETS.reduce<Record<string, string>>(
+    (acc, { key, label, color }) => {
+      const darkColors: Record<string, string> = {
+        pos1To3: '#3db7ad',
+        pos4To10: '#2a9189',
+        pos11To20: '#1f6f69',
+        pos21Plus: '#164f4c',
+      }
+      acc[label] = theme === 'dark' ? darkColors[key] : color
+      return acc
+    },
+    {},
+  )
+
+  return {
+    data: {
+      columns: [[seriesLabel, ...values]],
+      type: bar(),
+      colors: {
+        [seriesLabel]: (d: any) => {
+          const label = SEO_IMPRESSION_POSITION_BUCKETS[d.index]?.label
+          return label ? colors[label] : colors[labels[0]]
+        },
+      },
+    },
+    axis: {
+      x: {
+        type: 'category',
+        categories: labels,
+        tick: {
+          format: (index: number) => axisLabels[index] || labels[index] || '',
+          multiline: true,
+        },
+      },
+      y: {
+        min: 0,
+        padding: { bottom: 0 },
+        tick: {
+          format: (d: number) => nFormatter(d, 1),
+        },
+        show: true,
+        inner: true,
+      },
+    },
+    bar: {
+      width: {
+        ratio: 0.55,
+      },
+      radius: {
+        ratio: 0.12,
+      },
+    },
+    grid: {
+      y: {
+        show: true,
+      },
+    },
+    legend: {
+      show: false,
+    },
+    resize: {
+      auto: true,
+      timer: true,
+    },
+    transition: {
+      duration: 200,
+    },
+    tooltip: {
+      contents: (items) => {
+        const item = items[0]
+        if (!item) return ''
+
+        const bucketDef = SEO_IMPRESSION_POSITION_BUCKETS[item.index]
+        const bucket = bucketDef ? bucketMap.get(bucketDef.key) : null
+        const formattedValue = `${nFormatter(bucket?.impressions ?? 0, 1)} (${(bucket?.percentage ?? 0).toFixed(1)}%)`
+        const swatchColor = bucketDef ? colors[bucketDef.label] : '#14b8a6'
+
+        return `<ul class='bg-gray-50 dark:text-gray-50 dark:bg-slate-900 rounded-md ring-1 ring-black/10 px-2 py-1 text-xs md:text-sm shadow-md z-50'>
+          <li class='font-semibold pb-1 mb-1 border-b border-gray-200 dark:border-slate-800'>${bucketDef?.label ?? ''}</li>
+          <li class='flex justify-between items-center py-px leading-snug'>
+            <div class='flex items-center min-w-0 mr-4'>
+              <div class='w-2.5 h-2.5 rounded-xs mr-1.5 shrink-0' style=background-color:${swatchColor}></div>
+              <span class="truncate">${seriesLabel}</span>
+            </div>
+            <span class='font-mono whitespace-nowrap'>${formattedValue}</span>
+          </li>
+        </ul>`
+      },
+    },
+    padding: { right: 12 },
+  }
+}
+
+export function buildOrganicPositionsChartOptions(
+  series: OrganicPositionEntry[],
+  theme: string,
+  t: TFunction,
+): ChartOptions {
+  const labels = SEO_ORGANIC_POSITION_BUCKETS.map(({ label }) => label)
+  const columns: any[] = [
+    ['x', ...series.map(({ date }) => date)],
+    ...SEO_ORGANIC_POSITION_BUCKETS.map(({ key, label }) => [
+      label,
+      ...series.map((entry) => entry[key] ?? 0),
+    ]),
+  ]
+  const colors = SEO_ORGANIC_POSITION_BUCKETS.reduce<Record<string, string>>(
+    (acc, { key, label, color }) => {
+      const darkColors: Record<string, string> = {
+        pos1To3: '#b45309',
+        pos4To10: '#ea580c',
+        pos11To20: '#fb923c',
+        pos21To50: '#64748b',
+        pos51Plus: '#475569',
+      }
+      acc[label] = theme === 'dark' ? darkColors[key] : color
+      return acc
+    },
+    {},
+  )
+
+  return {
+    data: {
+      x: 'x',
+      xFormat: '%Y-%m-%d',
+      columns,
+      type: area(),
+      groups: [labels],
+      colors,
+      order: null,
+    },
+    area: {
+      linearGradient: true,
+      zerobased: true,
+    },
+    axis: {
+      x: {
+        clipPath: false,
+        type: 'timeseries',
+        tick: {
+          fit: true,
+          format: '%b %d',
+        },
+      },
+      y: {
+        min: 0,
+        padding: { bottom: 0 },
+        tick: {
+          format: (d: number) => nFormatter(d, 1),
+        },
+        show: true,
+        inner: true,
+      },
+    },
+    point: {
+      show: false,
+    },
+    grid: {
+      y: {
+        show: true,
+      },
+    },
+    legend: {
+      item: {
+        tile: {
+          type: 'circle',
+          width: 10,
+          r: 3,
+        },
+      },
+    },
+    resize: {
+      auto: true,
+      timer: true,
+    },
+    transition: {
+      duration: 200,
+    },
+    tooltip: {
+      contents: (items, _defaultTitleFormat, _defaultValueFormat, color) => {
+        if (!items.length) return ''
+
+        const headerLabel = d3.timeFormat('%a, %d %b')(items[0].x)
+        const orderedItems = items.slice().reverse()
+        const allPositions = orderedItems.reduce(
+          (sum: number, el: any) => sum + Number(el.value || 0),
+          0,
+        )
+
+        return `<ul class='bg-gray-50 dark:text-gray-50 dark:bg-slate-900 rounded-md ring-1 ring-black/10 px-2 py-1 text-xs md:text-sm max-h-[250px] md:max-h-[350px] overflow-y-auto shadow-md z-50'>
+          <li class='font-semibold pb-1 mb-1 border-b border-gray-200 dark:border-slate-800 sticky top-0 bg-gray-50 dark:bg-slate-900'>${headerLabel}</li>
+          <li class='flex justify-between items-center py-px leading-snug'>
+            <span class='mr-4 font-semibold'>${t('project.seo.allPositions')}</span>
+            <span class='font-mono whitespace-nowrap font-semibold'>${nFormatter(allPositions, 1)}</span>
+          </li>
+          ${orderedItems
+            .map(
+              (el: any) => `
+          <li class='flex justify-between items-center py-px leading-snug'>
+            <div class='flex items-center min-w-0 mr-4'>
+              <div class='w-2.5 h-2.5 rounded-xs mr-1.5 shrink-0' style=background-color:${color(el.id)}></div>
+              <span class="truncate">${escapeHtml(el.name)}</span>
+            </div>
+            <span class='font-mono whitespace-nowrap'>${nFormatter(el.value, 1)}</span>
+          </li>`,
+            )
+            .join('')}
+        </ul>`
+      },
+    },
+    padding: { right: 12 },
   }
 }
 
@@ -330,11 +657,26 @@ export function buildDonutChartOptions(
       },
     },
     tooltip: {
-      format: {
-        value: (value: number, ratio: number) => {
-          const pct = (ratio * 100).toFixed(1)
-          return `${nFormatter(value, 1)} (${pct}%)`
-        },
+      contents: (items, _defaultTitleFormat, _defaultValueFormat, color) => {
+        if (!items.length) return ''
+
+        return `<ul class='bg-gray-50 dark:text-gray-50 dark:bg-slate-900 rounded-md ring-1 ring-black/10 px-2 py-1 text-xs md:text-sm shadow-md z-50'>
+          <li class='font-semibold pb-1 mb-1 border-b border-gray-200 dark:border-slate-800'>${t('project.seo.brandedTraffic')}</li>
+          ${items
+            .map((el: any) => {
+              const pct = total > 0 ? (Number(el.value || 0) / total) * 100 : 0
+
+              return `
+          <li class='flex justify-between items-center py-px leading-snug'>
+            <div class='flex items-center min-w-0 mr-4'>
+              <div class='w-2.5 h-2.5 rounded-xs mr-1.5 shrink-0' style=background-color:${color(el.id)}></div>
+              <span class="truncate">${escapeHtml(el.name)}</span>
+            </div>
+            <span class='font-mono whitespace-nowrap'>${nFormatter(el.value, 1)} (${pct.toFixed(1)}%)</span>
+          </li>`
+            })
+            .join('')}
+        </ul>`
       },
     },
     size: {

--- a/web/app/pages/Project/tabs/SEO/seo-utils.ts
+++ b/web/app/pages/Project/tabs/SEO/seo-utils.ts
@@ -15,6 +15,38 @@ export const SEO_METRICS = {
 
 export type SEOMetricKey = keyof typeof SEO_METRICS
 
+export const SEO_IMPRESSION_POSITION_BUCKETS = [
+  { key: 'pos1To3', label: '1-3', color: '#134e4a' },
+  { key: 'pos4To10', label: '4-10', color: '#0f766e' },
+  { key: 'pos11To20', label: '11-20', color: '#14b8a6' },
+  { key: 'pos21Plus', label: '21+', color: '#99d9d4' },
+] as const
+
+export const SEO_ORGANIC_POSITION_BUCKETS = [
+  { key: 'pos1To3', label: '1-3', color: '#b45309' },
+  { key: 'pos4To10', label: '4-10', color: '#f97316' },
+  { key: 'pos11To20', label: '11-20', color: '#fb923c' },
+  { key: 'pos21To50', label: '21-50', color: '#cbd5e1' },
+  { key: 'pos51Plus', label: '51+', color: '#e2e8f0' },
+] as const
+
+export type SEOImpressionPositionBucketKey =
+  (typeof SEO_IMPRESSION_POSITION_BUCKETS)[number]['key']
+export type SEOOrganicPositionBucketKey =
+  (typeof SEO_ORGANIC_POSITION_BUCKETS)[number]['key']
+
+export interface ImpressionsByPositionEntry {
+  key: SEOImpressionPositionBucketKey
+  label: string
+  impressions: number
+  percentage: number
+}
+
+export type OrganicPositionEntry = { date: string } & Record<
+  SEOOrganicPositionBucketKey,
+  number
+>
+
 export interface DateSeriesEntry {
   date: string
   clicks: number
@@ -109,3 +141,10 @@ export const getGSCCompatibleFilters = (filters: Filter[]): Filter[] => {
     return []
   })
 }
+
+export const hasOrganicPositionData = (
+  series: OrganicPositionEntry[],
+): boolean =>
+  series.some((entry) =>
+    SEO_ORGANIC_POSITION_BUCKETS.some(({ key }) => (entry[key] ?? 0) > 0),
+  )

--- a/web/app/styles/ProjectViewStyle.css
+++ b/web/app/styles/ProjectViewStyle.css
@@ -109,6 +109,28 @@ body.dark .bb-ygrid {
   stroke: var(--color-red-400) !important;
 }
 
+.seo-impressions-position-chart .bb-bar {
+  fill-opacity: 0.85 !important;
+  stroke: none !important;
+  stroke-width: 0 !important;
+}
+
+.seo-impressions-position-chart .bb-axis-x .tick tspan {
+  font-weight: 600;
+}
+
+.seo-impressions-position-chart .bb-axis-x .tick tspan:nth-child(2) {
+  fill: var(--color-gray-600);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+body.dark .seo-impressions-position-chart .bb-axis-x .tick tspan:nth-child(2) {
+  fill: var(--color-slate-300);
+}
+
 /* Revenue chart styling */
 .bb-target-revenue .bb-bar {
   stroke: #ea580c;

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -1695,6 +1695,10 @@
       "brandedTraffic": "Branded traffic",
       "others": "Others",
       "noBrandData": "No query data",
+      "impressionsByPosition": "Impressions by position",
+      "organicPositions": "Organic positions",
+      "allPositions": "All positions",
+      "noPositionData": "No position data",
       "quadrant": "SEO Quadrant",
       "quadrantTooltip": "Each bubble is a search query. X-axis is ranking position (left = higher rank), Y-axis is click-through rate, and bubble size reflects impressions.\n\n<highlight>Top-left</highlight>: high rank + high CTR (your best performers).\n<highlight>Bottom-left</highlight>: high rank but low CTR (improve your title & description).\n<highlight>Top-right</highlight>: low rank but high CTR (boost these to page 1 for big gains).\n<highlight>Bottom-right</highlight>: low rank + low CTR (lowest priority)."
     },


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [x] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [ ] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added position analytics: impressions-by-position breakdown and organic positions time series with two new SEO chart panels
  * Compare-to-previous-period overlay and URL-driven time-bucket selection for SEO charts
  * Dashboard responses and dashboard hook extended to expose/reset position analytics and compare data

* **Documentation**
  * Updated SEO docs with compare-period instructions and Position Analytics guidance

* **Chores**
  * Added translations and chart styling for the new panels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Swetrix/swetrix/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->