### PR TITLE
fix: normalize ClickHouse import timestamps

### DIFF
--- a/backend/apps/community/src/data-import/data-import.service.ts
+++ b/backend/apps/community/src/data-import/data-import.service.ts
@@ -20,6 +20,34 @@ const IMPORT_IN_PROGRESS_ERROR =
 const IMPORT_CREATE_LOCK_TTL_MS = 10_000
 const IMPORT_CREATE_LOCK_WAIT_MS = 5_000
 const IMPORT_CREATE_LOCK_RETRY_MS = 100
+const CLICKHOUSE_DATE_TIME_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
+
+function formatClickHouseDateTime(value: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19)
+  }
+
+  if (CLICKHOUSE_DATE_TIME_REGEX.test(value)) {
+    return value
+  }
+
+  const date = new Date(value)
+  if (!Number.isNaN(date.getTime())) {
+    return date.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19)
+  }
+
+  return value.replace('T', ' ').replace(/Z$/, '').slice(0, 19)
+}
+
+function formatNullableClickHouseDateTime(
+  value: Date | string | null | undefined,
+): string | null {
+  if (!value) {
+    return null
+  }
+
+  return formatClickHouseDateTime(value)
+}
 
 @Injectable()
 export class DataImportService {
@@ -115,11 +143,7 @@ export class DataImportService {
 
       const id = await this.getNextId(projectId)
 
-      const now = new Date()
-        .toISOString()
-        .replace('T', ' ')
-        .replace('Z', '')
-        .slice(0, 19)
+      const now = formatClickHouseDateTime(new Date())
 
       await clickhouse.insert({
         table: `${CLICKHOUSE_DB}.data_import`,
@@ -219,6 +243,12 @@ export class DataImportService {
           ...updates,
           id,
           projectId,
+          createdAt: formatClickHouseDateTime(
+            updates.createdAt ?? existing.createdAt,
+          ),
+          finishedAt: formatNullableClickHouseDateTime(
+            updates.finishedAt ?? existing.finishedAt,
+          ),
           version: nextVersion,
         },
       ],
@@ -243,11 +273,7 @@ export class DataImportService {
       dateTo: string | null
     },
   ): Promise<void> {
-    const now = new Date()
-      .toISOString()
-      .replace('T', ' ')
-      .replace('Z', '')
-      .slice(0, 19)
+    const now = formatClickHouseDateTime(new Date())
     await this.updateStatus(id, projectId, {
       status: DataImportStatus.COMPLETED,
       importedRows: stats.importedRows,
@@ -264,11 +290,7 @@ export class DataImportService {
     projectId: string,
     errorMessage: string,
   ): Promise<void> {
-    const now = new Date()
-      .toISOString()
-      .replace('T', ' ')
-      .replace('Z', '')
-      .slice(0, 19)
+    const now = formatClickHouseDateTime(new Date())
     await this.updateStatus(id, projectId, {
       status: DataImportStatus.FAILED,
       errorMessage,

--- a/backend/apps/community/src/data-import/data-import.service.ts
+++ b/backend/apps/community/src/data-import/data-import.service.ts
@@ -21,6 +21,8 @@ const IMPORT_CREATE_LOCK_TTL_MS = 10_000
 const IMPORT_CREATE_LOCK_WAIT_MS = 5_000
 const IMPORT_CREATE_LOCK_RETRY_MS = 100
 const CLICKHOUSE_DATE_TIME_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
+const ISO_DATE_TIME_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/
 
 function formatClickHouseDateTime(value: Date | string): string {
   if (value instanceof Date) {
@@ -31,12 +33,14 @@ function formatClickHouseDateTime(value: Date | string): string {
     return value
   }
 
-  const date = new Date(value)
-  if (!Number.isNaN(date.getTime())) {
-    return date.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19)
+  if (ISO_DATE_TIME_REGEX.test(value)) {
+    const date = new Date(value)
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19)
+    }
   }
 
-  return value.replace('T', ' ').replace(/Z$/, '').slice(0, 19)
+  throw new Error('Invalid datetime input')
 }
 
 function formatNullableClickHouseDateTime(


### PR DESCRIPTION
### Changes

https://github.com/Swetrix/swetrix/issues/551

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized date/time formatting for data import timestamps to ensure consistent ClickHouse-compatible values (including nullable timestamps).
  * Ensured creation and status updates reliably record normalized createdAt and finishedAt values.
  * Replaced ad-hoc timestamp trimming with unified formatting to reduce inconsistencies and edge-case failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Swetrix/swetrix/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->