### PR TITLE
fix: improve SEO loading state and GSC long-range data

### DIFF
--- a/backend/apps/cloud/src/analytics/analytics.controller.ts
+++ b/backend/apps/cloud/src/analytics/analytics.controller.ts
@@ -43,7 +43,7 @@ import { DEFAULT_TIMEZONE } from '../user/entities/user.entity'
 import { AuthenticationGuard } from '../auth/guards/authentication.guard'
 import { PageviewsDto } from './dto/pageviews.dto'
 import { EventsDto } from './dto/events.dto'
-import { GetDataDto, ChartRenderMode } from './dto/getData.dto'
+import { GetDataDto, ChartRenderMode, TimeBucketType } from './dto/getData.dto'
 import { GetCustomEventMetadata } from './dto/get-custom-event-meta.dto'
 import { GetPagePropertyMetaDto } from './dto/get-page-property-meta.dto'
 import { GetUserFlowDto } from './dto/getUserFlow.dto'
@@ -1084,9 +1084,16 @@ export class AnalyticsController {
 
     await this.analyticsService.checkBillingAccess(pid)
 
-    const finalTimeBucket =
-      timeBucket ||
-      (['1h', 'today', 'yesterday', '1d'].includes(period) ? 'hour' : 'day')
+    const defaultTimeBucket = ['1h', 'today', 'yesterday', '1d'].includes(
+      period,
+    )
+      ? TimeBucketType.HOUR
+      : TimeBucketType.DAY
+    const finalTimeBucket = (timeBucket || defaultTimeBucket) as TimeBucketType
+    let groupTimeBucket: TimeBucketType | null = finalTimeBucket
+    if (period === 'all' || period === 'custom') {
+      groupTimeBucket = null
+    }
 
     this.logger.log(
       `pid: ${pid}, period: ${period}, timeBucket: ${finalTimeBucket}, filters: ${filters}`,
@@ -1099,7 +1106,7 @@ export class AnalyticsController {
     const { groupFrom, groupTo } = this.analyticsService.getGroupFromTo(
       from,
       to,
-      null,
+      groupTimeBucket,
       period,
       safeTimezone,
       diff,

--- a/backend/apps/cloud/src/project/gsc.service.ts
+++ b/backend/apps/cloud/src/project/gsc.service.ts
@@ -41,6 +41,7 @@ const MAX_ROW_LIMIT = 25000
 const MAX_BRANDED_PAGES = 10
 const MAX_FILTER_EXPRESSION_LENGTH = 500
 const MAX_FILTERS = 20
+const MAX_EXPENSIVE_ANALYTICS_RANGE_DAYS = 180
 
 const IMPRESSION_POSITION_BUCKETS = [
   { key: 'pos1To3', label: '1-3' },
@@ -511,7 +512,7 @@ export class GSCService {
         }
       } else if (column === 'device' || column === 'dv') {
         dimension = 'device'
-        expression = expression.toLowerCase()
+        expression = expression.toUpperCase()
       } else {
         continue
       }
@@ -747,9 +748,9 @@ export class GSCService {
 
     try {
       const rows = await this.queryGSC(gsc, from, to, {
-        dimensions: isHourly ? ['HOUR'] : ['date'],
+        dimensions: isHourly ? ['hour'] : ['date'],
         rowLimit: 5000,
-        dataState: isHourly ? 'HOURLY_ALL' : 'all',
+        dataState: isHourly ? 'hourly_all' : 'all',
         dimensionFilterGroups,
       })
 
@@ -1091,6 +1092,9 @@ export class GSCService {
     const fromDate = dayjs(from)
     const toDate = dayjs(to)
     const durationMs = toDate.diff(fromDate)
+    const rangeDays = Math.abs(toDate.diff(fromDate, 'day'))
+    const shouldLoadExpensiveAnalytics =
+      rangeDays <= MAX_EXPENSIVE_ANALYTICS_RANGE_DAYS
     const prevTo = fromDate
       .subtract(1, 'millisecond')
       .format('YYYY-MM-DD HH:mm:ss')
@@ -1116,10 +1120,17 @@ export class GSCService {
       this.getKeywords(pid, from, to, 50, 0, filtersStr, undefined, ctx),
       this.getTopCountries(pid, from, to, 50, 0, filtersStr, ctx),
       this.getTopDevices(pid, from, to, 50, 0, filtersStr, ctx),
-      this.getBrandedTraffic(pid, from, to, filtersStr, ctx),
-      this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
-        emptyPositionAnalytics(),
-      ),
+      shouldLoadExpensiveAnalytics
+        ? this.getBrandedTraffic(pid, from, to, filtersStr, ctx).catch(() => ({
+            branded: 0,
+            nonBranded: 0,
+          }))
+        : Promise.resolve({ branded: 0, nonBranded: 0 }),
+      shouldLoadExpensiveAnalytics
+        ? this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
+            emptyPositionAnalytics(),
+          )
+        : Promise.resolve(emptyPositionAnalytics()),
     ])
 
     return {

--- a/backend/apps/cloud/src/project/gsc.service.ts
+++ b/backend/apps/cloud/src/project/gsc.service.ts
@@ -65,6 +65,38 @@ type OrganicPositionSeriesEntry = { date: string } & Record<
   OrganicPositionBucketKey,
   number
 >
+type BrandedTrafficAnalytics = { branded: number; nonBranded: number }
+type SkippedBrandedAnalytics = {
+  skipped: true
+  branded: null
+  nonBranded: null
+}
+type PositionAnalytics = {
+  impressionsByPosition: {
+    key: ImpressionPositionBucketKey
+    label: string
+    impressions: number
+    percentage: number
+  }[]
+  organicPositions: OrganicPositionSeriesEntry[]
+}
+type SkippedPositionAnalytics = {
+  skipped: true
+  impressionsByPosition: null
+  organicPositions: null
+}
+
+const SKIPPED_BRANDED_ANALYTICS: SkippedBrandedAnalytics = {
+  skipped: true,
+  branded: null,
+  nonBranded: null,
+}
+
+const SKIPPED_POSITION_ANALYTICS: SkippedPositionAnalytics = {
+  skipped: true,
+  impressionsByPosition: null,
+  organicPositions: null,
+}
 
 const initialImpressionPositionBuckets = (): Record<
   ImpressionPositionBucketKey,
@@ -85,16 +117,6 @@ const initialOrganicPositionEntry = (
   pos11To20: 0,
   pos21To50: 0,
   pos51Plus: 0,
-})
-
-const emptyPositionAnalytics = () => ({
-  impressionsByPosition: IMPRESSION_POSITION_BUCKETS.map(({ key, label }) => ({
-    key,
-    label,
-    impressions: 0,
-    percentage: 0,
-  })),
-  organicPositions: [] as OrganicPositionSeriesEntry[],
 })
 
 const getImpressionPositionBucketKey = (
@@ -908,7 +930,7 @@ export class GSCService {
     to: string,
     filtersStr?: string,
     ctx?: GSCContext,
-  ): Promise<{ branded: number; nonBranded: number }> {
+  ): Promise<BrandedTrafficAnalytics> {
     const brandKeywords = await this.getProjectBrandKeywords(pid)
     if (_isEmpty(brandKeywords)) {
       return { branded: 0, nonBranded: 0 }
@@ -965,15 +987,7 @@ export class GSCService {
     to: string,
     filtersStr?: string,
     ctx?: GSCContext,
-  ): Promise<{
-    impressionsByPosition: {
-      key: ImpressionPositionBucketKey
-      label: string
-      impressions: number
-      percentage: number
-    }[]
-    organicPositions: OrganicPositionSeriesEntry[]
-  }> {
+  ): Promise<PositionAnalytics> {
     const gsc = ctx || (await this.getGSCContext(pid))
     const dimensionFilterGroups = this.getDimensionFilterGroups(filtersStr)
 
@@ -1121,16 +1135,15 @@ export class GSCService {
       this.getTopCountries(pid, from, to, 50, 0, filtersStr, ctx),
       this.getTopDevices(pid, from, to, 50, 0, filtersStr, ctx),
       shouldLoadExpensiveAnalytics
-        ? this.getBrandedTraffic(pid, from, to, filtersStr, ctx).catch(() => ({
-            branded: 0,
-            nonBranded: 0,
-          }))
-        : Promise.resolve({ branded: 0, nonBranded: 0 }),
-      shouldLoadExpensiveAnalytics
-        ? this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
-            emptyPositionAnalytics(),
+        ? this.getBrandedTraffic(pid, from, to, filtersStr, ctx).catch(
+            () => SKIPPED_BRANDED_ANALYTICS,
           )
-        : Promise.resolve(emptyPositionAnalytics()),
+        : Promise.resolve(SKIPPED_BRANDED_ANALYTICS),
+      shouldLoadExpensiveAnalytics
+        ? this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(
+            () => SKIPPED_POSITION_ANALYTICS,
+          )
+        : Promise.resolve(SKIPPED_POSITION_ANALYTICS),
     ])
 
     return {
@@ -1143,6 +1156,7 @@ export class GSCService {
       topCountries,
       topDevices,
       brandedTraffic,
+      positionAnalyticsSkipped: 'skipped' in positionAnalytics,
       impressionsByPosition: positionAnalytics.impressionsByPosition,
       organicPositions: positionAnalytics.organicPositions,
     }

--- a/backend/apps/community/src/analytics/analytics.controller.ts
+++ b/backend/apps/community/src/analytics/analytics.controller.ts
@@ -40,7 +40,7 @@ import { DEFAULT_TIMEZONE } from '../user/entities/user.entity'
 import { AuthenticationGuard } from '../auth/guards/authentication.guard'
 import { PageviewsDto } from './dto/pageviews.dto'
 import { EventsDto } from './dto/events.dto'
-import { GetDataDto, ChartRenderMode } from './dto/getData.dto'
+import { GetDataDto, ChartRenderMode, TimeBucketType } from './dto/getData.dto'
 import { GetFiltersDto } from './dto/get-filters.dto'
 import { GetVersionFiltersDto } from './dto/get-version-filters.dto'
 import { GetCustomEventMetadata } from './dto/get-custom-event-meta.dto'
@@ -2720,9 +2720,16 @@ export class AnalyticsController {
       headers['x-password'],
     )
 
-    const finalTimeBucket =
-      timeBucket ||
-      (['1h', 'today', 'yesterday', '1d'].includes(period) ? 'hour' : 'day')
+    const defaultTimeBucket = ['1h', 'today', 'yesterday', '1d'].includes(
+      period,
+    )
+      ? TimeBucketType.HOUR
+      : TimeBucketType.DAY
+    const finalTimeBucket = (timeBucket || defaultTimeBucket) as TimeBucketType
+    let groupTimeBucket: TimeBucketType | null = finalTimeBucket
+    if (period === 'all' || period === 'custom') {
+      groupTimeBucket = null
+    }
 
     this.logger.log(
       `pid: ${pid}, period: ${period}, timeBucket: ${finalTimeBucket}, filters: ${filters}`,
@@ -2735,7 +2742,7 @@ export class AnalyticsController {
     const { groupFrom, groupTo } = this.analyticsService.getGroupFromTo(
       from,
       to,
-      null,
+      groupTimeBucket,
       period,
       safeTimezone,
       diff,

--- a/backend/apps/community/src/project/gsc.service.ts
+++ b/backend/apps/community/src/project/gsc.service.ts
@@ -65,6 +65,38 @@ type OrganicPositionSeriesEntry = { date: string } & Record<
   OrganicPositionBucketKey,
   number
 >
+type BrandedTrafficAnalytics = { branded: number; nonBranded: number }
+type SkippedBrandedAnalytics = {
+  skipped: true
+  branded: null
+  nonBranded: null
+}
+type PositionAnalytics = {
+  impressionsByPosition: {
+    key: ImpressionPositionBucketKey
+    label: string
+    impressions: number
+    percentage: number
+  }[]
+  organicPositions: OrganicPositionSeriesEntry[]
+}
+type SkippedPositionAnalytics = {
+  skipped: true
+  impressionsByPosition: null
+  organicPositions: null
+}
+
+const SKIPPED_BRANDED_ANALYTICS: SkippedBrandedAnalytics = {
+  skipped: true,
+  branded: null,
+  nonBranded: null,
+}
+
+const SKIPPED_POSITION_ANALYTICS: SkippedPositionAnalytics = {
+  skipped: true,
+  impressionsByPosition: null,
+  organicPositions: null,
+}
 
 const initialImpressionPositionBuckets = (): Record<
   ImpressionPositionBucketKey,
@@ -85,16 +117,6 @@ const initialOrganicPositionEntry = (
   pos11To20: 0,
   pos21To50: 0,
   pos51Plus: 0,
-})
-
-const emptyPositionAnalytics = () => ({
-  impressionsByPosition: IMPRESSION_POSITION_BUCKETS.map(({ key, label }) => ({
-    key,
-    label,
-    impressions: 0,
-    percentage: 0,
-  })),
-  organicPositions: [] as OrganicPositionSeriesEntry[],
 })
 
 const getImpressionPositionBucketKey = (
@@ -969,7 +991,7 @@ export class GSCService {
     to: string,
     filtersStr?: string,
     ctx?: GSCContext,
-  ): Promise<{ branded: number; nonBranded: number }> {
+  ): Promise<BrandedTrafficAnalytics> {
     const brandKeywords = await this.getProjectBrandKeywords(pid)
     if (_isEmpty(brandKeywords)) {
       return { branded: 0, nonBranded: 0 }
@@ -1026,15 +1048,7 @@ export class GSCService {
     to: string,
     filtersStr?: string,
     ctx?: GSCContext,
-  ): Promise<{
-    impressionsByPosition: {
-      key: ImpressionPositionBucketKey
-      label: string
-      impressions: number
-      percentage: number
-    }[]
-    organicPositions: OrganicPositionSeriesEntry[]
-  }> {
+  ): Promise<PositionAnalytics> {
     const gsc = ctx || (await this.getGSCContext(pid))
     const dimensionFilterGroups = this.getDimensionFilterGroups(filtersStr)
 
@@ -1186,16 +1200,15 @@ export class GSCService {
       this.getTopCountries(pid, from, to, 50, 0, filtersStr, ctx),
       this.getTopDevices(pid, from, to, 50, 0, filtersStr, ctx),
       shouldLoadExpensiveAnalytics
-        ? this.getBrandedTraffic(pid, from, to, filtersStr, ctx).catch(() => ({
-            branded: 0,
-            nonBranded: 0,
-          }))
-        : Promise.resolve({ branded: 0, nonBranded: 0 }),
-      shouldLoadExpensiveAnalytics
-        ? this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
-            emptyPositionAnalytics(),
+        ? this.getBrandedTraffic(pid, from, to, filtersStr, ctx).catch(
+            () => SKIPPED_BRANDED_ANALYTICS,
           )
-        : Promise.resolve(emptyPositionAnalytics()),
+        : Promise.resolve(SKIPPED_BRANDED_ANALYTICS),
+      shouldLoadExpensiveAnalytics
+        ? this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(
+            () => SKIPPED_POSITION_ANALYTICS,
+          )
+        : Promise.resolve(SKIPPED_POSITION_ANALYTICS),
     ])
 
     return {
@@ -1208,6 +1221,7 @@ export class GSCService {
       topCountries,
       topDevices,
       brandedTraffic,
+      positionAnalyticsSkipped: 'skipped' in positionAnalytics,
       impressionsByPosition: positionAnalytics.impressionsByPosition,
       organicPositions: positionAnalytics.organicPositions,
     }

--- a/backend/apps/community/src/project/gsc.service.ts
+++ b/backend/apps/community/src/project/gsc.service.ts
@@ -41,6 +41,7 @@ const MAX_ROW_LIMIT = 25000
 const MAX_BRANDED_PAGES = 10
 const MAX_FILTER_EXPRESSION_LENGTH = 500
 const MAX_FILTERS = 20
+const MAX_EXPENSIVE_ANALYTICS_RANGE_DAYS = 180
 
 const IMPRESSION_POSITION_BUCKETS = [
   { key: 'pos1To3', label: '1-3' },
@@ -570,7 +571,7 @@ export class GSCService {
         }
       } else if (column === 'device' || column === 'dv') {
         dimension = 'device'
-        expression = expression.toLowerCase()
+        expression = expression.toUpperCase()
       } else {
         continue
       }
@@ -808,9 +809,9 @@ export class GSCService {
 
     try {
       const rows = await this.queryGSC(gsc, from, to, {
-        dimensions: isHourly ? ['HOUR'] : ['date'],
+        dimensions: isHourly ? ['hour'] : ['date'],
         rowLimit: 5000,
-        dataState: isHourly ? 'HOURLY_ALL' : 'all',
+        dataState: isHourly ? 'hourly_all' : 'all',
         dimensionFilterGroups,
       })
 
@@ -1156,6 +1157,9 @@ export class GSCService {
     const fromDate = dayjs(from)
     const toDate = dayjs(to)
     const durationMs = toDate.diff(fromDate)
+    const rangeDays = Math.abs(toDate.diff(fromDate, 'day'))
+    const shouldLoadExpensiveAnalytics =
+      rangeDays <= MAX_EXPENSIVE_ANALYTICS_RANGE_DAYS
     const prevTo = fromDate
       .subtract(1, 'millisecond')
       .format('YYYY-MM-DD HH:mm:ss')
@@ -1181,10 +1185,17 @@ export class GSCService {
       this.getKeywords(pid, from, to, 50, 0, filtersStr, undefined, ctx),
       this.getTopCountries(pid, from, to, 50, 0, filtersStr, ctx),
       this.getTopDevices(pid, from, to, 50, 0, filtersStr, ctx),
-      this.getBrandedTraffic(pid, from, to, filtersStr, ctx),
-      this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
-        emptyPositionAnalytics(),
-      ),
+      shouldLoadExpensiveAnalytics
+        ? this.getBrandedTraffic(pid, from, to, filtersStr, ctx).catch(() => ({
+            branded: 0,
+            nonBranded: 0,
+          }))
+        : Promise.resolve({ branded: 0, nonBranded: 0 }),
+      shouldLoadExpensiveAnalytics
+        ? this.getPositionAnalytics(pid, from, to, filtersStr, ctx).catch(() =>
+            emptyPositionAnalytics(),
+          )
+        : Promise.resolve(emptyPositionAnalytics()),
     ])
 
     return {

--- a/web/app/api/api.server.ts
+++ b/web/app/api/api.server.ts
@@ -34,8 +34,12 @@ export function getClientIP(request: Request): string | null {
 async function fetchWithTimeout(
   input: string | URL,
   init: Parameters<typeof fetch>[1] = {},
-  timeoutMs = 15000,
+  timeoutMs?: number,
 ): Promise<Response> {
+  if (timeoutMs === undefined) {
+    return fetch(input, init)
+  }
+
   const controller = new AbortController()
   const id = setTimeout(() => controller.abort(), timeoutMs)
   return fetch(input, { ...init, signal: controller.signal }).finally(() =>
@@ -219,6 +223,7 @@ export async function streamingServerFetch(
     body,
     headers: customHeaders = {},
     skipAuth = false,
+    timeoutMs,
   } = options
 
   const cleanEndpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint
@@ -246,11 +251,17 @@ export async function streamingServerFetch(
     }
   }
 
-  const response = await fetch(url, {
-    method,
-    headers: fetchHeaders,
-    body: body ? JSON.stringify(body) : undefined,
-  })
+  const serializedBody = body ? JSON.stringify(body) : undefined
+
+  const response = await fetchWithTimeout(
+    url,
+    {
+      method,
+      headers: fetchHeaders,
+      body: serializedBody,
+    },
+    timeoutMs,
+  )
 
   // If 401/403, try to refresh the token and retry
   if ((response.status === 401 || response.status === 403) && !skipAuth) {
@@ -260,11 +271,15 @@ export async function streamingServerFetch(
       fetchHeaders['Authorization'] =
         `Bearer ${refreshResult.tokens.accessToken}`
 
-      const retryResponse = await fetch(url, {
-        method,
-        headers: fetchHeaders,
-        body: body ? JSON.stringify(body) : undefined,
-      })
+      const retryResponse = await fetchWithTimeout(
+        url,
+        {
+          method,
+          headers: fetchHeaders,
+          body: serializedBody,
+        },
+        timeoutMs,
+      )
 
       // If the response is not ok, we still want to propagate the refreshed cookies
       const finalResponse = new Response(retryResponse.body, retryResponse)
@@ -2750,6 +2765,18 @@ type GSCOrganicPositionEntry = { date: string } & Record<
   number
 >
 
+interface GSCBrandedTraffic {
+  branded: number
+  nonBranded: number
+  skipped?: false
+}
+
+interface GSCSkippedBrandedTraffic {
+  skipped: true
+  branded: null
+  nonBranded: null
+}
+
 export interface GSCDashboardResponse {
   notConnected?: boolean
   noProperty?: boolean
@@ -2770,12 +2797,10 @@ export interface GSCDashboardResponse {
   topQueries?: GSCTopQueryEntry[]
   topCountries?: GSCTopCountryEntry[]
   topDevices?: GSCTopDeviceEntry[]
-  brandedTraffic?: {
-    branded: number
-    nonBranded: number
-  }
-  impressionsByPosition?: GSCImpressionsByPositionEntry[]
-  organicPositions?: GSCOrganicPositionEntry[]
+  brandedTraffic?: GSCBrandedTraffic | GSCSkippedBrandedTraffic
+  positionAnalyticsSkipped?: boolean
+  impressionsByPosition?: GSCImpressionsByPositionEntry[] | null
+  organicPositions?: GSCOrganicPositionEntry[] | null
 }
 
 export async function getGSCDashboardServer(

--- a/web/app/api/api.server.ts
+++ b/web/app/api/api.server.ts
@@ -49,6 +49,7 @@ interface ServerFetchOptions {
   headers?: Record<string, string>
   /** Skip authentication - for public endpoints */
   skipAuth?: boolean
+  timeoutMs?: number
 }
 
 interface ServerFetchResult<T> {
@@ -69,6 +70,7 @@ export async function serverFetch<T = unknown>(
     body,
     headers: customHeaders = {},
     skipAuth = false,
+    timeoutMs = 15000,
   } = options
 
   const cleanEndpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint
@@ -105,11 +107,15 @@ export async function serverFetch<T = unknown>(
     : undefined
 
   try {
-    const response = await fetchWithTimeout(url, {
-      method,
-      headers: fetchHeaders,
-      body: serializedBody,
-    })
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method,
+        headers: fetchHeaders,
+        body: serializedBody,
+      },
+      timeoutMs,
+    )
 
     if ((response.status === 401 || response.status === 403) && !skipAuth) {
       const refreshResult = await tryRefreshToken(request)
@@ -118,11 +124,15 @@ export async function serverFetch<T = unknown>(
         fetchHeaders['Authorization'] =
           `Bearer ${refreshResult.tokens.accessToken}`
 
-        const retryResponse = await fetchWithTimeout(url, {
-          method,
-          headers: fetchHeaders,
-          body: serializedBody,
-        })
+        const retryResponse = await fetchWithTimeout(
+          url,
+          {
+            method,
+            headers: fetchHeaders,
+            body: serializedBody,
+          },
+          timeoutMs,
+        )
 
         if (retryResponse.ok) {
           const retryContentType = retryResponse.headers.get('content-type')
@@ -2801,6 +2811,7 @@ export async function getGSCDashboardServer(
     `log/gsc-dashboard?${queryParams.toString()}`,
     {
       headers,
+      timeoutMs: 60000,
     },
   )
 }

--- a/web/app/hooks/useAnalyticsProxy.ts
+++ b/web/app/hooks/useAnalyticsProxy.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import type {
   SessionsResponse,
@@ -837,9 +837,12 @@ export function useGSCDashboardProxy() {
   const [data, setData] = useState<GSCDashboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const requestIdRef = useRef(0)
 
   const fetchDashboard = useCallback(
     async (projectId: string, params: ClientAnalyticsParams = {}) => {
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
       setIsLoading(true)
       setError(null)
 
@@ -849,20 +852,32 @@ export function useGSCDashboardProxy() {
           projectId,
           params,
         })
-        setData(result.data)
+
+        if (requestId !== requestIdRef.current) {
+          return result.data
+        }
+
+        if (result.data) {
+          setData(result.data)
+        }
         setError(result.error)
         return result.data
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error')
+        if (requestId === requestIdRef.current) {
+          setError(err instanceof Error ? err.message : 'Unknown error')
+        }
         return null
       } finally {
-        setIsLoading(false)
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false)
+        }
       }
     },
     [],
   )
 
   const resetData = useCallback(() => {
+    requestIdRef.current += 1
     setData(null)
     setError(null)
     setIsLoading(false)

--- a/web/app/pages/Project/tabs/SEO/SEOView.tsx
+++ b/web/app/pages/Project/tabs/SEO/SEOView.tsx
@@ -411,10 +411,15 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     [data?.topDevices],
   )
 
-  const brandedTraffic = useMemo(
-    () => data?.brandedTraffic || { branded: 0, nonBranded: 0 },
-    [data?.brandedTraffic],
-  )
+  const isBrandedTrafficSkipped = data?.brandedTraffic?.skipped === true
+
+  const brandedTraffic = useMemo(() => {
+    if (!data?.brandedTraffic || data.brandedTraffic.skipped) {
+      return { branded: 0, nonBranded: 0 }
+    }
+
+    return data.brandedTraffic
+  }, [data?.brandedTraffic])
 
   const donutChartOptions = useMemo(
     () =>
@@ -436,6 +441,11 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     () => data?.organicPositions || [],
     [data?.organicPositions],
   )
+
+  const isPositionAnalyticsSkipped =
+    data?.positionAnalyticsSkipped === true ||
+    data?.impressionsByPosition === null ||
+    data?.organicPositions === null
 
   const hasImpressionsByPositionData = useMemo(
     () => impressionsByPosition.some((bucket) => bucket.impressions > 0),
@@ -903,7 +913,9 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
               {t('project.seo.brandedTraffic')}
             </Text>
           </div>
-          {brandedTraffic.branded + brandedTraffic.nonBranded > 0 ? (
+          {isBrandedTrafficSkipped ? (
+            <PanelEmptyState message={t('project.seo.analyticsSkipped')} />
+          ) : brandedTraffic.branded + brandedTraffic.nonBranded > 0 ? (
             <BillboardChart
               options={donutChartOptions}
               className='[&_.bb-chart-arc]:text-xs [&_.bb-chart-arcs-title]:fill-gray-900 [&_.bb-chart-arcs-title]:text-lg [&_.bb-chart-arcs-title]:font-semibold dark:[&_.bb-chart-arcs-title]:fill-gray-100'
@@ -922,7 +934,9 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
           type='impressionsByPosition'
           contentClassName='relative flex min-h-[21rem] flex-col overflow-hidden'
         >
-          {hasImpressionsByPositionData ? (
+          {isPositionAnalyticsSkipped ? (
+            <PanelEmptyState message={t('project.seo.analyticsSkipped')} />
+          ) : hasImpressionsByPositionData ? (
             <BillboardChart
               options={impressionsByPositionOptions}
               className='seo-impressions-position-chart min-h-72 flex-1 [&_svg]:overflow-visible!'
@@ -939,7 +953,9 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
           type='organicPositions'
           contentClassName='relative flex min-h-[21rem] flex-col overflow-hidden'
         >
-          {hasOrganicPositions ? (
+          {isPositionAnalyticsSkipped ? (
+            <PanelEmptyState message={t('project.seo.analyticsSkipped')} />
+          ) : hasOrganicPositions ? (
             <BillboardChart
               options={organicPositionsOptions}
               className='min-h-80 flex-1 [&_svg]:overflow-visible!'

--- a/web/app/pages/Project/tabs/SEO/SEOView.tsx
+++ b/web/app/pages/Project/tabs/SEO/SEOView.tsx
@@ -56,6 +56,7 @@ import type { ProjectLoaderData } from '~/routes/projects.$id'
 import Checkbox from '~/ui/Checkbox'
 import Dropdown from '~/ui/Dropdown'
 import Loader from '~/ui/Loader'
+import LoadingBar from '~/ui/LoadingBar'
 import { Text } from '~/ui/Text'
 import Tooltip from '~/ui/Tooltip'
 import { nFormatter } from '~/utils/generic'
@@ -103,10 +104,12 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     isActiveCompare,
   } = useViewProjectContext()
   const { seoRefreshTrigger } = useRefreshTriggers()
-  const { fetchDashboard, data, isLoading } = useGSCDashboardProxy()
+  const { fetchDashboard, data, error, isLoading } = useGSCDashboardProxy()
   const {
     fetchDashboard: fetchCompareDashboard,
     data: compareData,
+    error: compareError,
+    isLoading: isCompareLoading,
     resetData: resetCompareData,
   } = useGSCDashboardProxy()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -237,6 +240,8 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
 
   const noopFilterLink = useCallback(() => '#', [])
   const gscFilters = useMemo(() => getGSCCompatibleFilters(filters), [filters])
+  const gscLoading = isLoading || isCompareLoading
+  const gscError = error || compareError
 
   const [isManualRefreshing, setIsManualRefreshing] = useState(false)
 
@@ -307,8 +312,11 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
   const handleManualRefresh = useCallback(async () => {
     if (isManualRefreshing) return
     setIsManualRefreshing(true)
-    await loadData()
-    setIsManualRefreshing(false)
+    try {
+      await loadData()
+    } finally {
+      setIsManualRefreshing(false)
+    }
   }, [isManualRefreshing, loadData])
 
   const manualRefreshButton = useMemo(
@@ -645,7 +653,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
     [t],
   )
 
-  if (isLoading && !data) {
+  if (gscLoading && !data) {
     return (
       <>
         <DashboardHeader
@@ -661,6 +669,32 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
         />
         <div className='flex min-h-[400px] items-center justify-center'>
           <Loader />
+        </div>
+      </>
+    )
+  }
+
+  if (gscError && !data) {
+    return (
+      <>
+        <DashboardHeader
+          showSearchButton={false}
+          showRefreshButton={false}
+          rightContent={
+            <ProjectViewHeaderActions
+              tnMapping={tnMapping}
+              extraActions={manualRefreshButton}
+            />
+          }
+          timeBucketSelectorItems={seoPeriodPairs}
+        />
+        <div className='mx-auto flex min-h-[400px] max-w-xl flex-col items-center justify-center px-4 text-center'>
+          <Text as='h3' size='lg' weight='medium'>
+            {t('apiNotifications.somethingWentWrong')}
+          </Text>
+          <Text as='p' size='sm' colour='secondary' className='mt-2'>
+            {gscError}
+          </Text>
         </div>
       </>
     )
@@ -735,6 +769,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
       {filters.length > 0 ? (
         <Filters className='mb-3' tnMapping={tnMapping} />
       ) : null}
+      {gscLoading && data ? <LoadingBar /> : null}
 
       <div className='relative overflow-hidden rounded-lg border border-gray-200 bg-white p-4 dark:border-slate-800/60 dark:bg-slate-900/25'>
         <div className='mb-3 flex w-full items-center justify-end gap-1 lg:absolute lg:top-2 lg:right-2 lg:mb-0 lg:w-auto lg:justify-normal'>
@@ -928,7 +963,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
           valuesHeaderName={t('project.seo.clicks')}
           detailsExtraColumns={detailsExtraColumns}
           hidePercentageInDetails
-          dataLoading={isLoading}
+          dataLoading={gscLoading}
           rowTooltipRenderer={seoGscRowTooltip}
           rowTooltipFollowCursor
         />
@@ -943,7 +978,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
           valuesHeaderName={t('project.seo.clicks')}
           detailsExtraColumns={detailsExtraColumns}
           hidePercentageInDetails
-          dataLoading={isLoading}
+          dataLoading={gscLoading}
           rowTooltipRenderer={seoGscRowTooltip}
           rowTooltipFollowCursor
         />
@@ -998,7 +1033,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
           valuesHeaderName={t('project.seo.clicks')}
           detailsExtraColumns={detailsExtraColumns}
           hidePercentageInDetails
-          dataLoading={isLoading}
+          dataLoading={gscLoading}
         />
         <Panel
           name={t('project.devices')}
@@ -1013,7 +1048,7 @@ const SEOViewInner = ({ projectId, tnMapping }: SEOViewProps) => {
           valuesHeaderName={t('project.seo.clicks')}
           detailsExtraColumns={detailsExtraColumns}
           hidePercentageInDetails
-          dataLoading={isLoading}
+          dataLoading={gscLoading}
         />
       </div>
     </>

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -1783,6 +1783,7 @@
       "brandedTraffic": "Branded traffic",
       "others": "Others",
       "noBrandData": "No query data",
+      "analyticsSkipped": "Skipped for this date range",
       "impressionsByPosition": "Impressions by position",
       "organicPositions": "Organic positions",
       "allPositions": "All positions",


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [ ] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [ ] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [ ] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loading bar overlay during GSC dashboard refresh; explicit "skipped" analytics empty states shown when data is unavailable.

* **Bug Fixes**
  * Prevented stale API responses from overwriting current dashboard data.
  * Improved loading/error/no-data handling in SEO analytics views.
  * Added configurable request timeouts with a longer timeout for GSC dashboard requests.

* **Performance**
  * Expensive analytics are skipped automatically for date ranges beyond 180 days.

* **Localization**
  * Added "Skipped for this date range" translation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Swetrix/swetrix/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->