### PR TITLE
fix analytics timezone fallback for drilldowns

### DIFF
--- a/web/app/routes/projects.$id.tsx
+++ b/web/app/routes/projects.$id.tsx
@@ -13,6 +13,7 @@ import { data, redirect } from 'react-router'
 
 import {
   serverFetch,
+  authMeServer,
   getProjectDataServer,
   getOverallStatsServer,
   getCustomEventsDataServer,
@@ -549,6 +550,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     cookies.push(createProjectPasswordCookie(projectId || '', password))
   }
 
+  let userTimezone = DEFAULT_TIMEZONE
+  if (hasAuthTokens(request)) {
+    const authResult = await authMeServer(request)
+    cookies.push(...authResult.cookies)
+
+    if (authResult.data?.user?.timezone) {
+      userTimezone = authResult.data.user.timezone
+    }
+  }
+
   // Parse URL params for analytics data
   const tab =
     (url.searchParams.get('tab') as keyof typeof PROJECT_TABS) ||
@@ -557,7 +568,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const urlTimeBucket = url.searchParams.get('timeBucket')
   const from = formatDateForBackend(url.searchParams.get('from') || '')
   const to = formatDateForBackend(url.searchParams.get('to') || '')
-  const timezone = url.searchParams.get('timezone') || DEFAULT_TIMEZONE
+  const timezone = url.searchParams.get('timezone') || userTimezone
   const filters = parseFiltersFromUrl(url.searchParams)
 
   // Ensure the time bucket is valid for the selected period and date range


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated users' timezone preferences are now automatically detected and applied to analytics and time-based server operations
  * Timezone can be customized via URL parameters, with automatic fallback to the user's account timezone for authenticated sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Swetrix/swetrix/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->