### PR TITLE
Support page tracking for noscript endpoint

### DIFF
--- a/backend/apps/cloud/src/analytics/analytics.controller.ts
+++ b/backend/apps/cloud/src/analytics/analytics.controller.ts
@@ -198,6 +198,29 @@ const TRANSPARENT_GIF_BUFFER = Buffer.from(
   'base64',
 )
 
+const getPagePath = (page?: string | string[] | null) => {
+  const value = Array.isArray(page) ? page[0] : page
+  if (!value) return null
+
+  const path = value.trim().split('#')[0].split('?')[0]
+  if (!path.startsWith('/') || path.startsWith('//')) return null
+
+  return path || '/'
+}
+
+const getPageFromReferrer = (referrer?: string | string[] | null) => {
+  const value = Array.isArray(referrer) ? referrer[0] : referrer
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    return getPagePath(url.pathname)
+  } catch {
+    return null
+  }
+}
+
 @ApiTags('Analytics')
 @UseGuards(OptionalJwtAccessTokenGuard, AuthenticationGuard)
 @UsePipes(
@@ -2051,6 +2074,9 @@ export class AnalyticsController {
   ) {
     const { 'user-agent': userAgent, origin } = headers
     const { pid } = data
+    const referrer = headers.referer || headers.referrer
+    const pg =
+      getPagePath(data.pg) || getPageFromReferrer(referrer) || undefined
 
     const ip = getIPFromHeaders(headers) || reqIP || ''
 
@@ -2059,8 +2085,8 @@ export class AnalyticsController {
       userAgent,
       headers,
       ip,
-      headers.referer || headers.referrer,
-      null,
+      referrer,
+      pg ?? null,
       'noscript',
     )
 
@@ -2069,7 +2095,7 @@ export class AnalyticsController {
       return res.end(TRANSPARENT_GIF_BUFFER, 'binary')
     }
 
-    const logDTO: PageviewsDto = { pid }
+    const logDTO: PageviewsDto = { pid, pg }
 
     const project = await this.analyticsService.validate(logDTO, origin, ip)
 
@@ -2104,7 +2130,7 @@ export class AnalyticsController {
 
     this.analyticsService.checkCountryBlacklist(project, country)
 
-    this.logger.log(`pid: ${pid}`, 'GET /analytics/noscript')
+    this.logger.log(`pid: ${pid}, pg: ${pg}`, 'GET /analytics/noscript')
 
     const { deviceType, browserName, browserVersion, osName, osVersion } =
       await this.analyticsService.getRequestInformation(headers)
@@ -2115,7 +2141,7 @@ export class AnalyticsController {
       profileId,
       pid: logDTO.pid,
       host: this.analyticsService.getHostFromOrigin(headers.origin),
-      pg: null,
+      pg,
       dv: deviceType,
       br: browserName,
       brv: browserVersion,

--- a/backend/apps/cloud/src/analytics/dto/noscript.dto.ts
+++ b/backend/apps/cloud/src/analytics/dto/noscript.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, Matches } from 'class-validator'
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { PID_REGEX } from '../../common/constants'
 
@@ -11,4 +17,15 @@ export class NoscriptDto {
   @IsNotEmpty()
   @Matches(PID_REGEX, { message: 'The provided Project ID (pid) is incorrect' })
   pid: string
+
+  @ApiProperty({
+    example: '/login',
+    required: false,
+    description: 'A page that user sent data from',
+    maxLength: 2048,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2048)
+  pg?: string
 }

--- a/backend/apps/community/src/analytics/analytics.controller.ts
+++ b/backend/apps/community/src/analytics/analytics.controller.ts
@@ -181,6 +181,29 @@ const TRANSPARENT_GIF_BUFFER = Buffer.from(
   'base64',
 )
 
+const getPagePath = (page?: string | string[] | null) => {
+  const value = Array.isArray(page) ? page[0] : page
+  if (!value) return null
+
+  const path = value.trim().split('#')[0].split('?')[0]
+  if (!path.startsWith('/') || path.startsWith('//')) return null
+
+  return path || '/'
+}
+
+const getPageFromReferrer = (referrer?: string | string[] | null) => {
+  const value = Array.isArray(referrer) ? referrer[0] : referrer
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    return getPagePath(url.pathname)
+  } catch {
+    return null
+  }
+}
+
 @ApiTags('Analytics')
 @UseGuards(OptionalJwtAccessTokenGuard, AuthenticationGuard)
 @UsePipes(
@@ -1538,8 +1561,11 @@ export class AnalyticsController {
   ) {
     const { 'user-agent': userAgent, origin } = headers
     const { pid } = data
+    const referrer = headers.referer || headers.referrer
+    const pg =
+      getPagePath(data.pg) || getPageFromReferrer(referrer) || undefined
 
-    const logDTO: PageviewsDto = { pid }
+    const logDTO: PageviewsDto = { pid, pg }
 
     const ip = getIPFromHeaders(headers) || reqIP || ''
 
@@ -1548,8 +1574,8 @@ export class AnalyticsController {
       userAgent,
       headers,
       ip,
-      headers.referer || headers.referrer,
-      null,
+      referrer,
+      pg ?? null,
       'noscript',
     )
 
@@ -1593,7 +1619,7 @@ export class AnalyticsController {
 
     this.analyticsService.checkCountryBlacklist(project, country)
 
-    this.logger.log(`pid: ${pid}`, 'GET /analytics/noscript')
+    this.logger.log(`pid: ${pid}, pg: ${pg}`, 'GET /analytics/noscript')
 
     const { deviceType, browserName, browserVersion, osName, osVersion } =
       await this.analyticsService.getRequestInformation(headers)
@@ -1604,7 +1630,7 @@ export class AnalyticsController {
       profileId,
       pid: logDTO.pid,
       host: this.analyticsService.getHostFromOrigin(headers.origin),
-      pg: null,
+      pg,
       dv: deviceType,
       br: browserName,
       brv: browserVersion,

--- a/backend/apps/community/src/analytics/dto/noscript.dto.ts
+++ b/backend/apps/community/src/analytics/dto/noscript.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, Matches } from 'class-validator'
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { PID_REGEX } from '../../common/constants'
 
@@ -11,4 +17,15 @@ export class NoscriptDto {
   @IsNotEmpty()
   @Matches(PID_REGEX, { message: 'The provided Project ID (pid) is incorrect' })
   pid: string
+
+  @ApiProperty({
+    example: '/login',
+    required: false,
+    description: 'A page that user sent data from',
+    maxLength: 2048,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2048)
+  pg?: string
 }

--- a/docs/content/docs/script-reference.mdx
+++ b/docs/content/docs/script-reference.mdx
@@ -119,6 +119,13 @@ The `trackViews` function returns a `Promise` with an object with some methods a
 }
 ```
 
+## Noscript fallback
+
+The `/log/noscript` image pixel records pageviews for visitors with JavaScript disabled.
+It accepts the required `pid` query parameter and an optional `pg` page path, for example `/` or `/login`.
+If `pg` is not provided, the API tries to recover it from the `Referer` header and stores only the URL pathname.
+If neither value is available, `pg` is stored as `null` and will be displayed in dashboard as `Not set`.
+
 ## pageview()
 
 This function is used to manually track a page view event.

--- a/web/app/pages/Project/View/Panels.tsx
+++ b/web/app/pages/Project/View/Panels.tsx
@@ -1909,9 +1909,7 @@ const DetailsTable = ({
       if (activeTabId === 'lc') {
         try {
           return (
-            getLocaleDisplayName(entry?.name, language) ||
-            entry?.name ||
-            ''
+            getLocaleDisplayName(entry?.name, language) || entry?.name || ''
           )
         } catch {
           return entry?.name || ''


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [x] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [ ] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional page (pg) parameter to analytics endpoints; system will normalize/derive it (including from Referer) and include it in tracking, validation, logging, and bot checks.
  * Improved pageview tracking for users with JavaScript disabled, with automatic fallback to referrer parsing.

* **Documentation**
  * Added noscript fallback docs describing pg usage and behavior when JavaScript is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->