### PR TITLE
[docs] Add OIDC redirect URI

### DIFF
--- a/docs/content/docs/selfhosting/configuring.mdx
+++ b/docs/content/docs/selfhosting/configuring.mdx
@@ -87,6 +87,9 @@ Swetrix Community Edition also supports OIDC authentication. To enable it, you n
 | `OIDC_CLIENT_SECRET` |                  | OIDC client secret                                                                                                                |
 | `OIDC_PROMPT`        | `select_account` | OIDC prompt                                                                                                                       |
 
+When configuring your OIDC provider, use `BASE_URL/socialised` (e.g. `https://analytics.example.com/socialised`) as the redirect URI.
+
+
 ## Redis
 
 | Variable         | Default    | Description    |


### PR DESCRIPTION
### Changes

Adds the OIDC redirect URI to the documentation.

### Community Edition support
- [ ] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [ ] No table schemas changed in this PR

### Documentation
- [x] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification in the self-hosting configuration guide regarding OIDC provider redirect URI setup, with example format provided for proper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->