### PR TITLE
fix: Session replay filters

### DIFF
--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -6908,22 +6908,23 @@ export class AnalyticsService {
       ),
       filtered_sessions AS (
         SELECT
-          toString(ifNull(e.psid, 0)) AS psidCasted,
-          e.pid AS pid,
+          ms.psidCasted AS psidCasted,
+          ms.pid AS pid,
           argMaxIf(e.profileId, toTimeZone(e.created, {timezone:String}), e.profileId IS NOT NULL AND e.profileId != '') AS profileId,
-          any(e.cc) AS cc,
-          any(e.os) AS os,
-          any(e.br) AS br,
-          min(toTimeZone(e.created, {timezone:String})) AS sessionStart,
-          max(toTimeZone(e.created, {timezone:String})) AS lastActivity
-        FROM events e
-        INNER JOIN matched_sessions ms ON toString(ifNull(e.psid, 0)) = ms.psidCasted AND e.pid = ms.pid
-        WHERE e.pid = {pid:FixedString(12)}
+          anyIf(e.cc, e.psid IS NOT NULL AND e.psid != 0) AS cc,
+          anyIf(e.os, e.psid IS NOT NULL AND e.psid != 0) AS os,
+          anyIf(e.br, e.psid IS NOT NULL AND e.psid != 0) AS br,
+          minOrNull(if(e.psid IS NOT NULL AND e.psid != 0, toTimeZone(e.created, {timezone:String}), NULL)) AS sessionStart,
+          maxOrNull(if(e.psid IS NOT NULL AND e.psid != 0, toTimeZone(e.created, {timezone:String}), NULL)) AS lastActivity
+        FROM matched_sessions ms
+        LEFT JOIN events e ON toString(ifNull(e.psid, 0)) = ms.psidCasted
+          AND e.pid = ms.pid
           AND e.type IN ('pageview', 'custom_event', 'error')
           AND e.psid IS NOT NULL
           AND e.psid != 0
           AND e.created BETWEEN {groupFrom:String} AND {groupTo:String}
-        GROUP BY psidCasted, pid
+        WHERE ms.pid = {pid:FixedString(12)}
+        GROUP BY ms.psidCasted, ms.pid
       )`
 
     const query = `
@@ -7187,7 +7188,7 @@ export class AnalyticsService {
           toTimeZone(matching_custom_events.created, {timezone:String}) AS created_for_grouping
         FROM sessions AS s FINAL
         INNER JOIN (
-          SELECT pid, profileId, cc, os, br, created
+          SELECT pid, psid, profileId, cc, os, br, created
           FROM events
           WHERE
             pid = {pid:FixedString(12)}
@@ -7205,6 +7206,7 @@ export class AnalyticsService {
         ) AS matching_custom_events
           ON s.pid = matching_custom_events.pid
           AND s.profileId = matching_custom_events.profileId
+          AND (matching_custom_events.psid IS NULL OR matching_custom_events.psid = 0 OR matching_custom_events.psid = s.psid)
         WHERE matching_custom_events.created BETWEEN s.firstSeen AND addSeconds(s.lastSeen, 1)
       `
     }

--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -6880,10 +6880,14 @@ export class AnalyticsService {
       filtersQuery,
       customEVFilterApplied,
       'traffic',
+      '',
+      true,
     )
 
-    const query = `
-      WITH filtered_sessions AS (
+    const filteredSessionsCTE =
+      _isEmpty(filtersQuery) && !customEVFilterApplied
+        ? `
+      filtered_sessions AS (
         SELECT
           psidCasted,
           pid,
@@ -6895,7 +6899,35 @@ export class AnalyticsService {
           max(created_for_grouping) AS lastActivity
         FROM (${primaryEventsSubquery}) AS primary_events
         GROUP BY psidCasted, pid
+      )`
+        : `
+      matched_sessions AS (
+        SELECT DISTINCT psidCasted, pid
+        FROM (${primaryEventsSubquery}) AS primary_events
+        WHERE psidCasted != '0'
       ),
+      filtered_sessions AS (
+        SELECT
+          toString(ifNull(e.psid, 0)) AS psidCasted,
+          e.pid AS pid,
+          argMaxIf(e.profileId, toTimeZone(e.created, {timezone:String}), e.profileId IS NOT NULL AND e.profileId != '') AS profileId,
+          any(e.cc) AS cc,
+          any(e.os) AS os,
+          any(e.br) AS br,
+          min(toTimeZone(e.created, {timezone:String})) AS sessionStart,
+          max(toTimeZone(e.created, {timezone:String})) AS lastActivity
+        FROM events e
+        INNER JOIN matched_sessions ms ON toString(ifNull(e.psid, 0)) = ms.psidCasted AND e.pid = ms.pid
+        WHERE e.pid = {pid:FixedString(12)}
+          AND e.type IN ('pageview', 'custom_event', 'error')
+          AND e.psid IS NOT NULL
+          AND e.psid != 0
+          AND e.created BETWEEN {groupFrom:String} AND {groupTo:String}
+        GROUP BY psidCasted, pid
+      )`
+
+    const query = `
+      WITH ${filteredSessionsCTE},
       replay_summary AS (
         SELECT
           psidCasted,
@@ -7123,6 +7155,7 @@ export class AnalyticsService {
     customEVFilterApplied: boolean,
     sessionEvent: SessionsListEventType = 'traffic',
     primaryEventFilterQuery = '',
+    includeProfileMatchedEventsWithPsid = false,
   ): string {
     if (customEVFilterApplied || sessionEvent === 'custom_event') {
       return `
@@ -7159,7 +7192,11 @@ export class AnalyticsService {
           WHERE
             pid = {pid:FixedString(12)}
             AND type = 'custom_event'
-            AND (psid IS NULL OR psid = 0)
+            ${
+              includeProfileMatchedEventsWithPsid
+                ? ''
+                : 'AND (psid IS NULL OR psid = 0)'
+            }
             AND profileId IS NOT NULL
             AND profileId != ''
             AND created BETWEEN {groupFrom:String} AND {groupTo:String}


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [ ] Your feature is implemented for the Swetrix Community Edition
- [x] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session replay list accuracy by better including profile-matched events that carry profile IDs.
  * More reliable session start and last-activity timestamps (timezone-aware), reducing incorrect session boundaries.
  * Reduced duplicate or mismatched events in replays by tightening event-to-session matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->