### PR TITLE
feat: Live visitors visualisation over time

### DIFF
--- a/backend/apps/cloud/src/analytics/analytics.controller.ts
+++ b/backend/apps/cloud/src/analytics/analytics.controller.ts
@@ -278,6 +278,7 @@ export class AnalyticsController {
       timezone = DEFAULT_TIMEZONE,
       mode = ChartRenderMode.PERIODICAL,
       metrics,
+      includeConcurrency,
     } = data
 
     await this.analyticsService.checkProjectAccess(
@@ -385,6 +386,7 @@ export class AnalyticsController {
         customEVFilterApplied,
         appliedFilters,
         mode,
+        includeConcurrency === 'true',
       )
     }
 
@@ -799,6 +801,7 @@ export class AnalyticsController {
       filters,
       timezone = DEFAULT_TIMEZONE,
       mode = ChartRenderMode.PERIODICAL,
+      includeConcurrency,
     } = data
 
     const [filtersQuery, filtersParams, appliedFilters, customEVFilterApplied] =
@@ -841,6 +844,7 @@ export class AnalyticsController {
       safeTimezone,
       customEVFilterApplied,
       mode,
+      includeConcurrency === 'true',
     )
 
     return { ...result, appliedFilters }

--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -139,6 +139,9 @@ const isValidLocale = (lc: string): boolean => {
 
 // 2 minutes
 const LIVE_SESSION_THRESHOLD_SECONDS = 120
+// The concurrency sweep materializes one row per minute of the requested window,
+// so cap how far back it can be reconstructed to keep the query bounded
+const MAX_CONCURRENCY_WINDOW_MINUTES = 366 * 24 * 60
 const MAX_FILTERS = 100
 const MAX_FILTER_VALUES = 100
 
@@ -5516,6 +5519,7 @@ export class AnalyticsService {
     customEVFilterApplied: boolean,
     parsedFilters: Array<{ [key: string]: string }>,
     mode: ChartRenderMode,
+    includeConcurrency = false,
   ): Promise<object | void> {
     let params: unknown = {}
     let chart: unknown = {}
@@ -5542,6 +5546,7 @@ export class AnalyticsService {
           safeTimezone,
           customEVFilterApplied,
           mode,
+          includeConcurrency,
         )
 
         // @ts-ignore
@@ -5694,7 +5699,7 @@ export class AnalyticsService {
               FROM session_intervals
               UNION ALL
               SELECT fromMinute + toIntervalMinute(number) AS m, toInt32(0) AS delta
-              FROM numbers(toUInt64(dateDiff('minute', fromMinute, toMinute)) + 1)
+              FROM numbers(least(toUInt64(dateDiff('minute', fromMinute, toMinute)) + 1, ${MAX_CONCURRENCY_WINDOW_MINUTES}))
             )
             GROUP BY m
           )
@@ -5733,6 +5738,7 @@ export class AnalyticsService {
     safeTimezone: string,
     customEVFilterApplied: boolean,
     mode: ChartRenderMode,
+    includeConcurrency = false,
   ): Promise<object | void> {
     const { xShifted } = this.generateXAxis(timeBucket, from, to, safeTimezone)
 
@@ -5743,9 +5749,17 @@ export class AnalyticsService {
       customEVFilterApplied,
     )
 
-    // The sessions table has no dimension columns, so concurrency cannot respect
-    // dashboard filters — return zeros instead of misleading unfiltered data
-    const shouldComputeConcurrency = !customEVFilterApplied && !filtersQuery
+    // Concurrency is only computed when explicitly requested (the live visitors
+    // metric is off by default) and within a bounded window — the sweep-line
+    // query materializes a row per minute. The sessions table also has no
+    // dimension columns, so concurrency cannot respect dashboard filters —
+    // return zeros instead of misleading unfiltered data
+    const shouldComputeConcurrency =
+      includeConcurrency &&
+      !customEVFilterApplied &&
+      !filtersQuery &&
+      dayjs.utc(to).diff(dayjs.utc(from), 'minute') <=
+        MAX_CONCURRENCY_WINDOW_MINUTES
 
     const [{ data }, concurrency] = await Promise.all([
       clickhouse

--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -5646,6 +5646,84 @@ export class AnalyticsService {
     }
   }
 
+  // Reconstructs the number of concurrent (live) visitors for each display bucket
+  // from the sessions table intervals [firstSeen, lastSeen] using a sweep-line:
+  // +1 at each session's start minute, -1 right after its end minute, a zero-delta
+  // "spine" row for every minute in the requested window, then a running sum gives
+  // exact per-minute concurrency. Buckets larger than a minute report the peak
+  // concurrency within the bucket.
+  generateConcurrencyAggregationQuery(timeBucket: TimeBucketType): string {
+    const timeBucketFunc = timeBucketConversion[timeBucket]
+    const [selector, groupBy] = this.getGroupSubquery(timeBucket)
+
+    return `
+      WITH
+        parseDateTimeBestEffort({groupFrom:String}) AS fromTs,
+        parseDateTimeBestEffort({groupTo:String}) AS toTs,
+        toStartOfMinute(fromTs) AS fromMinute,
+        toStartOfMinute(toTs) AS toMinute,
+        session_intervals AS (
+          SELECT
+            greatest(min(firstSeen), fromTs) AS sessionStart,
+            least(max(lastSeen), toTs) AS sessionEnd
+          FROM sessions
+          WHERE
+            pid = {pid:FixedString(12)}
+            AND firstSeen <= toTs
+            AND lastSeen >= fromTs
+          GROUP BY psid
+        )
+      SELECT
+        ${selector},
+        toInt32(max(concurrency)) AS concurrency
+      FROM (
+        SELECT
+          ${timeBucketFunc}(toTimeZone(m, {timezone:String})) AS tz_created,
+          concurrency
+        FROM (
+          SELECT
+            m,
+            sum(minute_delta) OVER (ORDER BY m ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS concurrency
+          FROM (
+            SELECT m, sum(delta) AS minute_delta
+            FROM (
+              SELECT toStartOfMinute(sessionStart) AS m, toInt32(1) AS delta
+              FROM session_intervals
+              UNION ALL
+              SELECT toStartOfMinute(sessionEnd) + INTERVAL 1 MINUTE AS m, toInt32(-1) AS delta
+              FROM session_intervals
+              UNION ALL
+              SELECT fromMinute + toIntervalMinute(number) AS m, toInt32(0) AS delta
+              FROM numbers(toUInt64(dateDiff('minute', fromMinute, toMinute)) + 1)
+            )
+            GROUP BY m
+          )
+        )
+        WHERE m BETWEEN fromMinute AND toMinute
+      )
+      GROUP BY ${groupBy}
+      ORDER BY ${groupBy}
+    `
+  }
+
+  async getConcurrencyChartData(
+    timeBucket: TimeBucketType,
+    paramsData: any,
+    safeTimezone: string,
+    xShifted: string[],
+  ): Promise<number[]> {
+    const query = this.generateConcurrencyAggregationQuery(timeBucket)
+
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: { ...paramsData.params, timezone: safeTimezone },
+      })
+      .then((resultSet) => resultSet.json<any>())
+
+    return this.extractCountsForSessionChart(data, xShifted, 'concurrency')
+  }
+
   async groupChartByTimeBucket(
     timeBucket: TimeBucketType,
     from: string,
@@ -5665,14 +5743,28 @@ export class AnalyticsService {
       customEVFilterApplied,
     )
 
-    const { data } = await clickhouse
-      .query({
-        query,
-        query_params: { ...paramsData.params, timezone: safeTimezone },
-      })
-      .then((resultSet) =>
-        resultSet.json<TrafficCHResponse | TrafficCEFilterCHResponse>(),
-      )
+    // The sessions table has no dimension columns, so concurrency cannot respect
+    // dashboard filters — return zeros instead of misleading unfiltered data
+    const shouldComputeConcurrency = !customEVFilterApplied && !filtersQuery
+
+    const [{ data }, concurrency] = await Promise.all([
+      clickhouse
+        .query({
+          query,
+          query_params: { ...paramsData.params, timezone: safeTimezone },
+        })
+        .then((resultSet) =>
+          resultSet.json<TrafficCHResponse | TrafficCEFilterCHResponse>(),
+        ),
+      shouldComputeConcurrency
+        ? this.getConcurrencyChartData(
+            timeBucket,
+            paramsData,
+            safeTimezone,
+            xShifted,
+          )
+        : Promise.resolve(Array(xShifted.length).fill(0)),
+    ])
 
     const { visits, uniques, sdur, bounces } =
       this.extractAnalyticsChartDataForScope(
@@ -5689,6 +5781,7 @@ export class AnalyticsService {
         uniques,
         sdur,
         bounces,
+        concurrency,
       },
     })
   }

--- a/backend/apps/cloud/src/analytics/dto/getData.dto.ts
+++ b/backend/apps/cloud/src/analytics/dto/getData.dto.ts
@@ -68,4 +68,12 @@ export class GetDataDto {
   })
   @IsOptional()
   metrics?: string
+
+  @ApiProperty({
+    description:
+      "Set to 'true' to include the live visitors (concurrency) series in the chart response",
+    required: false,
+  })
+  @IsOptional()
+  includeConcurrency?: string
 }

--- a/backend/apps/community/src/analytics/analytics.controller.ts
+++ b/backend/apps/community/src/analytics/analytics.controller.ts
@@ -240,6 +240,7 @@ export class AnalyticsController {
       timezone = DEFAULT_TIMEZONE,
       mode = ChartRenderMode.PERIODICAL,
       metrics,
+      includeConcurrency,
     } = data
 
     await this.analyticsService.checkProjectAccess(
@@ -342,6 +343,7 @@ export class AnalyticsController {
         customEVFilterApplied,
         parsedFilters,
         mode,
+        includeConcurrency === 'true',
       )
     }
 
@@ -705,6 +707,7 @@ export class AnalyticsController {
       filters,
       timezone = DEFAULT_TIMEZONE,
       mode = ChartRenderMode.PERIODICAL,
+      includeConcurrency,
     } = data
 
     const [filtersQuery, filtersParams, parsedFilters, customEVFilterApplied] =
@@ -737,6 +740,7 @@ export class AnalyticsController {
       safeTimezone,
       customEVFilterApplied,
       mode,
+      includeConcurrency === 'true',
     )
 
     return { ...result, appliedFilters: parsedFilters }

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -122,6 +122,9 @@ const isValidLocale = (lc: string): boolean => {
 
 // 2 minutes
 const LIVE_SESSION_THRESHOLD_SECONDS = 120
+// The concurrency sweep materializes one row per minute of the requested window,
+// so cap how far back it can be reconstructed to keep the query bounded
+const MAX_CONCURRENCY_WINDOW_MINUTES = 366 * 24 * 60
 const MAX_FILTERS = 100
 const MAX_FILTER_VALUES = 100
 
@@ -4064,6 +4067,7 @@ export class AnalyticsService {
     customEVFilterApplied: boolean,
     parsedFilters: Array<{ [key: string]: string }>,
     mode: ChartRenderMode,
+    includeConcurrency = false,
   ): Promise<object | void> {
     let params: unknown = {}
     let chart: unknown = {}
@@ -4090,6 +4094,7 @@ export class AnalyticsService {
           safeTimezone,
           customEVFilterApplied,
           mode,
+          includeConcurrency,
         )
 
         // @ts-ignore
@@ -4242,7 +4247,7 @@ export class AnalyticsService {
               FROM session_intervals
               UNION ALL
               SELECT fromMinute + toIntervalMinute(number) AS m, toInt32(0) AS delta
-              FROM numbers(toUInt64(dateDiff('minute', fromMinute, toMinute)) + 1)
+              FROM numbers(least(toUInt64(dateDiff('minute', fromMinute, toMinute)) + 1, ${MAX_CONCURRENCY_WINDOW_MINUTES}))
             )
             GROUP BY m
           )
@@ -4281,6 +4286,7 @@ export class AnalyticsService {
     safeTimezone: string,
     customEVFilterApplied: boolean,
     mode: ChartRenderMode,
+    includeConcurrency = false,
   ): Promise<object | void> {
     const { xShifted } = this.generateXAxis(timeBucket, from, to, safeTimezone)
 
@@ -4291,9 +4297,17 @@ export class AnalyticsService {
       customEVFilterApplied,
     )
 
-    // The sessions table has no dimension columns, so concurrency cannot respect
-    // dashboard filters — return zeros instead of misleading unfiltered data
-    const shouldComputeConcurrency = !customEVFilterApplied && !filtersQuery
+    // Concurrency is only computed when explicitly requested (the live visitors
+    // metric is off by default) and within a bounded window — the sweep-line
+    // query materializes a row per minute. The sessions table also has no
+    // dimension columns, so concurrency cannot respect dashboard filters —
+    // return zeros instead of misleading unfiltered data
+    const shouldComputeConcurrency =
+      includeConcurrency &&
+      !customEVFilterApplied &&
+      !filtersQuery &&
+      dayjs.utc(to).diff(dayjs.utc(from), 'minute') <=
+        MAX_CONCURRENCY_WINDOW_MINUTES
 
     const [{ data }, concurrency] = await Promise.all([
       clickhouse

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -4194,6 +4194,84 @@ export class AnalyticsService {
     }
   }
 
+  // Reconstructs the number of concurrent (live) visitors for each display bucket
+  // from the sessions table intervals [firstSeen, lastSeen] using a sweep-line:
+  // +1 at each session's start minute, -1 right after its end minute, a zero-delta
+  // "spine" row for every minute in the requested window, then a running sum gives
+  // exact per-minute concurrency. Buckets larger than a minute report the peak
+  // concurrency within the bucket.
+  generateConcurrencyAggregationQuery(timeBucket: TimeBucketType): string {
+    const timeBucketFunc = timeBucketConversion[timeBucket]
+    const [selector, groupBy] = this.getGroupSubquery(timeBucket)
+
+    return `
+      WITH
+        parseDateTimeBestEffort({groupFrom:String}) AS fromTs,
+        parseDateTimeBestEffort({groupTo:String}) AS toTs,
+        toStartOfMinute(fromTs) AS fromMinute,
+        toStartOfMinute(toTs) AS toMinute,
+        session_intervals AS (
+          SELECT
+            greatest(min(firstSeen), fromTs) AS sessionStart,
+            least(max(lastSeen), toTs) AS sessionEnd
+          FROM sessions
+          WHERE
+            pid = {pid:FixedString(12)}
+            AND firstSeen <= toTs
+            AND lastSeen >= fromTs
+          GROUP BY psid
+        )
+      SELECT
+        ${selector},
+        toInt32(max(concurrency)) AS concurrency
+      FROM (
+        SELECT
+          ${timeBucketFunc}(toTimeZone(m, {timezone:String})) AS tz_created,
+          concurrency
+        FROM (
+          SELECT
+            m,
+            sum(minute_delta) OVER (ORDER BY m ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS concurrency
+          FROM (
+            SELECT m, sum(delta) AS minute_delta
+            FROM (
+              SELECT toStartOfMinute(sessionStart) AS m, toInt32(1) AS delta
+              FROM session_intervals
+              UNION ALL
+              SELECT toStartOfMinute(sessionEnd) + INTERVAL 1 MINUTE AS m, toInt32(-1) AS delta
+              FROM session_intervals
+              UNION ALL
+              SELECT fromMinute + toIntervalMinute(number) AS m, toInt32(0) AS delta
+              FROM numbers(toUInt64(dateDiff('minute', fromMinute, toMinute)) + 1)
+            )
+            GROUP BY m
+          )
+        )
+        WHERE m BETWEEN fromMinute AND toMinute
+      )
+      GROUP BY ${groupBy}
+      ORDER BY ${groupBy}
+    `
+  }
+
+  async getConcurrencyChartData(
+    timeBucket: TimeBucketType,
+    paramsData: any,
+    safeTimezone: string,
+    xShifted: string[],
+  ): Promise<number[]> {
+    const query = this.generateConcurrencyAggregationQuery(timeBucket)
+
+    const { data } = await clickhouse
+      .query({
+        query,
+        query_params: { ...paramsData.params, timezone: safeTimezone },
+      })
+      .then((resultSet) => resultSet.json<any>())
+
+    return this.extractCountsForSessionChart(data, xShifted, 'concurrency')
+  }
+
   async groupChartByTimeBucket(
     timeBucket: TimeBucketType,
     from: string,
@@ -4213,14 +4291,28 @@ export class AnalyticsService {
       customEVFilterApplied,
     )
 
-    const { data } = await clickhouse
-      .query({
-        query,
-        query_params: { ...paramsData.params, timezone: safeTimezone },
-      })
-      .then((resultSet) =>
-        resultSet.json<TrafficCHResponse | TrafficCEFilterCHResponse>(),
-      )
+    // The sessions table has no dimension columns, so concurrency cannot respect
+    // dashboard filters — return zeros instead of misleading unfiltered data
+    const shouldComputeConcurrency = !customEVFilterApplied && !filtersQuery
+
+    const [{ data }, concurrency] = await Promise.all([
+      clickhouse
+        .query({
+          query,
+          query_params: { ...paramsData.params, timezone: safeTimezone },
+        })
+        .then((resultSet) =>
+          resultSet.json<TrafficCHResponse | TrafficCEFilterCHResponse>(),
+        ),
+      shouldComputeConcurrency
+        ? this.getConcurrencyChartData(
+            timeBucket,
+            paramsData,
+            safeTimezone,
+            xShifted,
+          )
+        : Promise.resolve(Array(xShifted.length).fill(0)),
+    ])
 
     const { visits, uniques, sdur, bounces } =
       this.extractAnalyticsChartDataForScope(
@@ -4237,6 +4329,7 @@ export class AnalyticsService {
         uniques,
         sdur,
         bounces,
+        concurrency,
       },
     })
   }

--- a/backend/apps/community/src/analytics/dto/getData.dto.ts
+++ b/backend/apps/community/src/analytics/dto/getData.dto.ts
@@ -68,4 +68,12 @@ export class GetDataDto {
   })
   @IsOptional()
   metrics?: string
+
+  @ApiProperty({
+    description:
+      "Set to 'true' to include the live visitors (concurrency) series in the chart response",
+    required: false,
+  })
+  @IsOptional()
+  includeConcurrency?: string
 }

--- a/docs/content/docs/analytics-dashboard/live-visitors.mdx
+++ b/docs/content/docs/analytics-dashboard/live-visitors.mdx
@@ -16,7 +16,7 @@ In the top right corner of your dashboard (and on the main Traffic overview), yo
 
 ## Live Visitors Over Time
 
-The live counter tells you what's happening right now, but you can also chart concurrency historically. Unlike unique visitors (which only count when a session starts), this metric shows how many people were using your site *at the same time* — so you can spot peak load, quiet hours, and how long people actually stay around.
+The live counter tells you what's happening right now, but you can also chart concurrency historically. Unlike unique visitors (which only count when a session starts), this metric shows how many people were using your site _at the same time_ — so you can spot peak load, quiet hours, and how long people actually stay around.
 
 To enable it:
 
@@ -32,7 +32,7 @@ How to read the chart:
 A visitor counts as active from their first pageview until their last recorded activity (pageviews, custom events, or the tracking script's periodic heartbeats), so the chart also works for single-page apps where people stay on one page for a long time.
 
 :::info
-Live visitors can't be combined with dashboard filters (country, page, browser, etc.), as concurrency is reconstructed from session activity that carries no dimension data. The metric toggle is disabled while filters are applied.
+Live visitors can't be combined with dashboard filters (country, page, browser, etc.), as concurrency is reconstructed from session activity that carries no dimension data. The metric toggle is disabled while filters are applied. The chart is also limited to time ranges of up to a year — for longer ranges it shows zeros.
 :::
 
 ## Live Visitors in Browser Title

--- a/docs/content/docs/analytics-dashboard/live-visitors.mdx
+++ b/docs/content/docs/analytics-dashboard/live-visitors.mdx
@@ -14,6 +14,27 @@ In the top right corner of your dashboard (and on the main Traffic overview), yo
 - **What it counts**: This number represents the count of unique visitors who have initiated a session or viewed a page within the last **5 minutes**.
 - **Updates**: The counter updates in real-time as new visitors arrive or existing ones leave (time out).
 
+## Live Visitors Over Time
+
+The live counter tells you what's happening right now, but you can also chart concurrency historically. Unlike unique visitors (which only count when a session starts), this metric shows how many people were using your site *at the same time* — so you can spot peak load, quiet hours, and how long people actually stay around.
+
+To enable it:
+
+1.  Open the **Traffic** dashboard.
+2.  Click the **Metrics visualisation** (eye) icon above the chart.
+3.  Check **Live visitors**.
+
+How to read the chart:
+
+- **Minute granularity** (e.g. the "Today" period): each point is the exact number of visitors who were active during that minute.
+- **Hour, day or month granularity**: each point is the **peak** number of concurrent visitors within that bucket. A value of 69 on Tuesday means that at some moment on Tuesday, 69 people were on your site at once.
+
+A visitor counts as active from their first pageview until their last recorded activity (pageviews, custom events, or the tracking script's periodic heartbeats), so the chart also works for single-page apps where people stay on one page for a long time.
+
+:::info
+Live visitors can't be combined with dashboard filters (country, page, browser, etc.), as concurrency is reconstructed from session activity that carries no dimension data. The metric toggle is disabled while filters are applied.
+:::
+
 ## Live Visitors in Browser Title
 
 You can configure Swetrix to display the live visitor count directly in your browser tab's title. This is useful for keeping an eye on traffic without having the dashboard tab active.

--- a/docs/content/docs/analytics-dashboard/traffic.mdx
+++ b/docs/content/docs/analytics-dashboard/traffic.mdx
@@ -20,6 +20,7 @@ The main chart visualizes various metrics to help you understand your traffic pe
 - **Pageviews**: The total number of pages viewed.
 - **Session Duration**: The average time visitors spend on your site per session.
 - **Bounce Rate**: The percentage of visitors who navigate away from the site after viewing only one page.
+- **Live Visitors**: How many people were using your site at the same time. At minute granularity this is the exact number of concurrent visitors; at hourly or larger granularity the chart shows the peak concurrency within each bucket. See [Live Visitors](/analytics-dashboard/live-visitors) for details.
 - **Views per Unique**: The average number of pages viewed by a single unique visitor.
 - **Revenue**: Total revenue generated (if revenue tracking is enabled).
 

--- a/docs/content/docs/api/stats.mdx
+++ b/docs/content/docs/api/stats.mdx
@@ -261,7 +261,8 @@ curl 'https://api.swetrix.com/v1/log?pid=YOUR_PROJECT_ID&timeBucket=day&period=7
     ],
     "visits": [0, 2, 9, 12, 4, 7, 4, 0],
     "uniques": [0, 2, 9, 10, 4, 7, 4, 0],
-    "sdur": [0, 54, 2, 126, 8, 8, 2]
+    "sdur": [0, 54, 2, 126, 8, 8, 2],
+    "concurrency": [0, 1, 3, 4, 2, 2, 1, 0]
   },
   "customs": {
     "sale": 16,
@@ -273,6 +274,10 @@ curl 'https://api.swetrix.com/v1/log?pid=YOUR_PROJECT_ID&timeBucket=day&period=7
   "appliedFilters": []
 }
 ```
+
+:::info
+`chart.concurrency` is the number of live (concurrent) visitors over time, reconstructed from session activity. For the `minute` time bucket it's the exact number of visitors active during that minute; for larger buckets it's the peak concurrency within the bucket. When `filters` are applied, this array is zero-filled, as concurrency cannot be segmented by dimensions.
+:::
 
 #### Parameters
 
@@ -1259,7 +1264,7 @@ The parameters are similar to the [`/log` endpoint](#get-v1log).
 
 ### GET /v1/log/chart
 
-Returns data for the main chart (visits, uniques, sessions duration, etc.) grouped by time bucket. This is useful when you only need the chart data without other aggregations.
+Returns data for the main chart (visits, uniques, sessions duration, concurrent live visitors, etc.) grouped by time bucket. This is useful when you only need the chart data without other aggregations.
 
 ```bash
 curl 'https://api.swetrix.com/v1/log/chart?pid=YOUR_PROJECT_ID&timeBucket=day&period=7d'\

--- a/docs/content/docs/api/stats.mdx
+++ b/docs/content/docs/api/stats.mdx
@@ -276,7 +276,7 @@ curl 'https://api.swetrix.com/v1/log?pid=YOUR_PROJECT_ID&timeBucket=day&period=7
 ```
 
 :::info
-`chart.concurrency` is the number of live (concurrent) visitors over time, reconstructed from session activity. For the `minute` time bucket it's the exact number of visitors active during that minute; for larger buckets it's the peak concurrency within the bucket. When `filters` are applied, this array is zero-filled, as concurrency cannot be segmented by dimensions.
+`chart.concurrency` is the number of live (concurrent) visitors over time, reconstructed from session activity. It is only computed when the request sets `includeConcurrency=true`; otherwise the array is zero-filled. For the `minute` time bucket it's the exact number of visitors active during that minute; for larger buckets it's the peak concurrency within the bucket. When `filters` are applied (or the requested time range is longer than a year), this array is zero-filled, as concurrency cannot be segmented by dimensions.
 :::
 
 #### Parameters
@@ -346,6 +346,12 @@ The `meta` is an array of objects like:
   },
 }
 ```
+
+<hr />
+
+**includeConcurrency**
+
+Set to `true` to include the `chart.concurrency` (live visitors over time) series in the response. Reconstructing concurrency from session intervals is relatively expensive, so it's skipped unless explicitly requested.
 
 <hr />
 

--- a/web/app/api/api.server.ts
+++ b/web/app/api/api.server.ts
@@ -740,6 +740,7 @@ export interface TrafficLogResponse {
     uniques: number[]
     sdur: number[]
     bounces?: number[]
+    concurrency?: number[]
   }
   customs: Record<string, number>
   properties: Record<string, number>

--- a/web/app/api/api.server.ts
+++ b/web/app/api/api.server.ts
@@ -783,6 +783,8 @@ export interface AnalyticsParams {
   mode?: 'periodical' | 'cumulative'
   password?: string
   metrics?: string
+  // Concurrency (live visitors) data is only computed by the API when requested
+  includeConcurrency?: boolean
 }
 
 function serializeFiltersForUrl(filters: AnalyticsFilter[]): string {
@@ -804,6 +806,9 @@ export async function getProjectDataServer(
   if (params.timezone) queryParams.append('timezone', params.timezone)
   if (params.mode) queryParams.append('mode', params.mode)
   if (params.metrics) queryParams.append('metrics', params.metrics)
+  if (params.includeConcurrency) {
+    queryParams.append('includeConcurrency', 'true')
+  }
 
   const headers: Record<string, string> = {}
   if (params.password) {

--- a/web/app/pages/Project/View/ViewProject.helpers.tsx
+++ b/web/app/pages/Project/View/ViewProject.helpers.tsx
@@ -251,6 +251,7 @@ const CHART_METRICS_MAPPING = {
   viewsPerUnique: 'viewsPerUnique',
   trendlines: 'trendlines',
   sessionDuration: 'sessionDuration',
+  liveVisitors: 'liveVisitors',
   customEvents: 'customEvents',
   cumulativeMode: 'cumulativeMode',
   revenue: 'revenue',
@@ -289,6 +290,7 @@ const getColumns = (
     unique,
     trendlines,
     sessionDuration,
+    liveVisitors,
     occurrences,
     avgResponseTime,
   } = activeChartMetrics
@@ -360,6 +362,14 @@ const getColumns = (
 
     if (compareChart?.sdur) {
       columns.push(['sessionDurationCompare', ...compareChart.sdur])
+    }
+  }
+
+  if (liveVisitors && chart.concurrency) {
+    columns.push(['liveVisitors', ...chart.concurrency])
+
+    if (compareChart?.concurrency) {
+      columns.push(['liveVisitorsCompare', ...compareChart.concurrency])
     }
   }
 
@@ -665,6 +675,11 @@ const getSettings = (
       ...chart.occurrences.filter((n) => n !== undefined && n !== null),
     )
   }
+  if (activeChartMetrics.liveVisitors && chart.concurrency) {
+    allYValues.push(
+      ...chart.concurrency.filter((n) => n !== undefined && n !== null),
+    )
+  }
 
   const optimalTicks =
     allYValues.length > 0 ? calculateOptimalTicks(allYValues) : undefined
@@ -719,6 +734,7 @@ const getSettings = (
       total: [regionObj],
       bounce: [regionObj],
       viewsPerUnique: [regionObj],
+      liveVisitors: [regionObj],
     }
   }
 
@@ -750,6 +766,8 @@ const getSettings = (
         sessionDuration: chartType === chartTypes.line ? spline() : bar(),
         sessionDurationCompare:
           chartType === chartTypes.line ? spline() : bar(),
+        liveVisitors: chartType === chartTypes.line ? spline() : bar(),
+        liveVisitorsCompare: chartType === chartTypes.line ? spline() : bar(),
         // Revenue is always bars (stacked with refunds)
         revenue: bar(),
         refundsAmount: bar(),
@@ -766,6 +784,8 @@ const getSettings = (
         trendlineTotal: '#eba14b',
         sessionDuration: '#c945ed',
         sessionDurationCompare: 'rgba(201, 69, 237, 0.4)',
+        liveVisitors: '#16A34A',
+        liveVisitorsCompare: 'rgba(22, 163, 74, 0.4)',
         revenue: '#ea580c', // orange-600 for net revenue
         refundsAmount: 'rgba(234, 88, 12, 0.25)', // light orange fill for refunds overlay
         ...customEventsColors,
@@ -854,6 +874,7 @@ const getSettings = (
           unique: 'uniques',
           total: 'visits',
           sessionDuration: 'sdur',
+          liveVisitors: 'concurrency',
         }
 
         if (_isEmpty(compareChart)) {
@@ -960,7 +981,8 @@ const getSettings = (
             el.id !== 'uniqueCompare' &&
             el.id !== 'totalCompare' &&
             el.id !== 'bounceCompare' &&
-            el.id !== 'sessionDurationCompare',
+            el.id !== 'sessionDurationCompare' &&
+            el.id !== 'liveVisitorsCompare',
         )
 
         // Build current period section
@@ -1049,6 +1071,7 @@ const getSettings = (
         'totalCompare',
         'bounceCompare',
         'sessionDurationCompare',
+        'liveVisitorsCompare',
         'refundsAmount',
       ],
     },

--- a/web/app/pages/Project/View/ViewProject.helpers.tsx
+++ b/web/app/pages/Project/View/ViewProject.helpers.tsx
@@ -784,8 +784,10 @@ const getSettings = (
         trendlineTotal: '#eba14b',
         sessionDuration: '#c945ed',
         sessionDurationCompare: 'rgba(201, 69, 237, 0.4)',
-        liveVisitors: '#16A34A',
-        liveVisitorsCompare: 'rgba(22, 163, 74, 0.4)',
+        // Distinct from every CUSTOM_EVENTS_CHART_COLORS entry so the legend
+        // stays unambiguous when both series are shown
+        liveVisitors: '#10B981',
+        liveVisitorsCompare: 'rgba(16, 185, 129, 0.4)',
         revenue: '#ea580c', // orange-600 for net revenue
         refundsAmount: 'rgba(234, 88, 12, 0.25)', // light orange fill for refunds overlay
         ...customEventsColors,

--- a/web/app/pages/Project/View/interfaces/traffic.ts
+++ b/web/app/pages/Project/View/interfaces/traffic.ts
@@ -60,6 +60,7 @@ export interface TrafficLogResponse {
     uniques: number[]
     sdur: number[]
     bounces?: number[]
+    concurrency?: number[]
   }
   customs: Customs
   properties: Properties

--- a/web/app/pages/Project/tabs/Traffic/TrafficView.tsx
+++ b/web/app/pages/Project/tabs/Traffic/TrafficView.tsx
@@ -411,11 +411,10 @@ const TrafficViewInner = ({
   const isPanelsDataEmpty = isPanelsDataEmptyRaw && !hasShownContentRef.current
 
   // Chart metrics state
-  const [activeChartMetrics, setActiveChartMetrics] = useState({
+  const [activeChartMetricsState, setActiveChartMetrics] = useState({
     [CHART_METRICS_MAPPING.unique]: true,
     [CHART_METRICS_MAPPING.views]: false,
     [CHART_METRICS_MAPPING.sessionDuration]: false,
-    [CHART_METRICS_MAPPING.liveVisitors]: false,
     [CHART_METRICS_MAPPING.bounce]: false,
     [CHART_METRICS_MAPPING.viewsPerUnique]: false,
     [CHART_METRICS_MAPPING.trendlines]: false,
@@ -423,6 +422,17 @@ const TrafficViewInner = ({
     [CHART_METRICS_MAPPING.customEvents]: false,
     [CHART_METRICS_MAPPING.revenue]: false,
   })
+
+  // Live visitors is URL-driven (like custom events) so the route loader knows
+  // to request concurrency data from the API — it is only computed on demand
+  const activeChartMetrics = useMemo(
+    () => ({
+      ...activeChartMetricsState,
+      [CHART_METRICS_MAPPING.liveVisitors]:
+        searchParams.get('liveVisitors') === 'true',
+    }),
+    [activeChartMetricsState, searchParams],
+  )
   // Get custom events from URL params (SSR-friendly)
   const activeChartMetricsCustomEvents = useMemo(() => {
     const param = searchParams.get('customEvents')
@@ -673,25 +683,32 @@ const TrafficViewInner = ({
         return
       }
 
+      if (pairID === CHART_METRICS_MAPPING.liveVisitors) {
+        const newParams = new URLSearchParams(searchParams.toString())
+        if (newParams.get('liveVisitors') === 'true') {
+          newParams.delete('liveVisitors')
+        } else {
+          newParams.set('liveVisitors', 'true')
+        }
+        setSearchParams(newParams)
+        return
+      }
+
       setActiveChartMetrics((prev) => ({
         ...prev,
         [pairID]: !prev[pairID as keyof typeof prev],
       }))
     },
-    [isConflicted, t],
+    [isConflicted, t, searchParams, setSearchParams],
   )
 
   // Live visitors cannot be filtered — turn it off if a filter gets applied
   // while it's active (the toggle itself is disabled in that state)
   useEffect(() => {
-    if (
-      !_isEmpty(filters) &&
-      activeChartMetrics[CHART_METRICS_MAPPING.liveVisitors]
-    ) {
-      setActiveChartMetrics((prev) => ({
-        ...prev,
-        [CHART_METRICS_MAPPING.liveVisitors]: false,
-      }))
+    if (!_isEmpty(filters) && searchParams.get('liveVisitors') === 'true') {
+      const newParams = new URLSearchParams(searchParams.toString())
+      newParams.delete('liveVisitors')
+      setSearchParams(newParams)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters])

--- a/web/app/pages/Project/tabs/Traffic/TrafficView.tsx
+++ b/web/app/pages/Project/tabs/Traffic/TrafficView.tsx
@@ -415,6 +415,7 @@ const TrafficViewInner = ({
     [CHART_METRICS_MAPPING.unique]: true,
     [CHART_METRICS_MAPPING.views]: false,
     [CHART_METRICS_MAPPING.sessionDuration]: false,
+    [CHART_METRICS_MAPPING.liveVisitors]: false,
     [CHART_METRICS_MAPPING.bounce]: false,
     [CHART_METRICS_MAPPING.viewsPerUnique]: false,
     [CHART_METRICS_MAPPING.trendlines]: false,
@@ -554,6 +555,15 @@ const TrafficViewInner = ({
           ],
         },
         {
+          id: CHART_METRICS_MAPPING.liveVisitors,
+          label: t('dashboard.liveVisitors'),
+          active: activeChartMetrics[CHART_METRICS_MAPPING.liveVisitors],
+          // Concurrency is reconstructed from session intervals which carry no
+          // dimension data, so it cannot respect dashboard filters
+          disabled: !_isEmpty(filters),
+          disabledTooltip: t('project.liveVisitorsFilterConflict'),
+        },
+        {
           id: CHART_METRICS_MAPPING.viewsPerUnique,
           label: t('dashboard.viewsPerUnique'),
           active: activeChartMetrics[CHART_METRICS_MAPPING.viewsPerUnique],
@@ -574,7 +584,7 @@ const TrafficViewInner = ({
           active: activeChartMetrics[CHART_METRICS_MAPPING.customEvents],
         },
       ].filter(Boolean),
-    [t, activeChartMetrics, isRevenueConnected],
+    [t, activeChartMetrics, isRevenueConnected, filters],
   )
 
   const chartMetricsCustomEvents = useMemo(() => {
@@ -608,6 +618,7 @@ const TrafficViewInner = ({
       trendlineUnique: t('project.trendlineUnique'),
       occurrences: t('project.occurrences'),
       sessionDuration: t('dashboard.sessionDuration'),
+      liveVisitors: t('dashboard.liveVisitors'),
       revenue: t('dashboard.revenue'),
       refundsAmount: t('dashboard.refunds'),
       ...dataNamesCustomEvents,
@@ -669,6 +680,21 @@ const TrafficViewInner = ({
     },
     [isConflicted, t],
   )
+
+  // Live visitors cannot be filtered — turn it off if a filter gets applied
+  // while it's active (the toggle itself is disabled in that state)
+  useEffect(() => {
+    if (
+      !_isEmpty(filters) &&
+      activeChartMetrics[CHART_METRICS_MAPPING.liveVisitors]
+    ) {
+      setActiveChartMetrics((prev) => ({
+        ...prev,
+        [CHART_METRICS_MAPPING.liveVisitors]: false,
+      }))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters])
 
   const switchCustomEventChart = useCallback(
     (eventId: string) => {
@@ -973,19 +999,30 @@ const TrafficViewInner = ({
                   )
                 }
 
-                return (
+                const checkbox = (
                   <Checkbox
                     classes={{
                       label: 'p-2',
                     }}
                     label={label}
-                    disabled={conflicted}
+                    disabled={conflicted || pair.disabled}
                     checked={active}
                     onChange={() => {
                       switchTrafficChartMetric(pairID, conflicts)
                     }}
                   />
                 )
+
+                if (pair.disabled && pair.disabledTooltip) {
+                  return (
+                    <Tooltip
+                      text={pair.disabledTooltip}
+                      tooltipNode={checkbox}
+                    />
+                  )
+                }
+
+                return checkbox
               }}
               buttonClassName='!p-1.5 rounded-md border border-transparent hover:border-gray-300 hover:bg-white hover:dark:border-slate-700/80 hover:dark:bg-slate-950 dark:focus:ring-slate-300'
               selectItemClassName='p-0'
@@ -996,6 +1033,10 @@ const TrafficViewInner = ({
                 const { id: pairID, conflicts } = pair
                 e?.stopPropagation()
                 e?.preventDefault()
+
+                if (pair.disabled) {
+                  return
+                }
 
                 if (pairID !== CHART_METRICS_MAPPING.customEvents) {
                   switchTrafficChartMetric(pairID, conflicts)

--- a/web/app/routes/projects.$id.tsx
+++ b/web/app/routes/projects.$id.tsx
@@ -608,6 +608,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   // Segment custom metrics (JSON-encoded ProjectViewCustomEvent[])
   const metricsParam = url.searchParams.get('metrics') || undefined
 
+  // Live visitors chart metric — concurrency data is only requested when enabled
+  const liveVisitorsEnabled = url.searchParams.get('liveVisitors') === 'true'
+
   const analyticsParams = {
     timeBucket,
     period,
@@ -617,6 +620,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     timezone,
     password: password || undefined,
     metrics: metricsParam,
+    includeConcurrency: liveVisitorsEnabled || undefined,
   }
 
   // Initialize deferred data promises

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -2196,6 +2196,7 @@
     "customEvMetadata": "Custom events metadata",
     "pageviewMetadata": "Pageview metadata",
     "conflictMetric": "The metric you selected conflicts with an already selected one",
+    "liveVisitorsFilterConflict": "Live visitors can't be shown while dashboard filters are applied",
     "prev": "Previous",
     "next": "Next",
     "results": "Results",


### PR DESCRIPTION
### Changes

https://github.com/Swetrix/swetrix/issues/331

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [x] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [ ] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Live Visitors** chart metric showing concurrent active visitors (with compare support).
  * Dashboard chart responses can now include **`chart.concurrency?: number[]`**, enabled via an **`includeConcurrency`** request flag.
* **Bug Fixes**
  * **Live Visitors** is automatically disabled (and hidden) when dashboard filters are applied; otherwise the chart returns a zero-filled concurrency series when it can’t be computed.
* **Documentation**
  * Updated analytics dashboard docs, API `/v1/log` stats examples, and live-visitors guidance/constraints (including max time-range behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->