### PR TITLE
A/B test asking users for a website URL on the hero section

### DIFF
--- a/web/app/components/marketing/HeroSignupForm.tsx
+++ b/web/app/components/marketing/HeroSignupForm.tsx
@@ -1,0 +1,83 @@
+import { ArrowRightIcon } from '@phosphor-icons/react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router'
+
+import FaviconGlyph from '~/ui/FaviconGlyph'
+import { trackCustom } from '~/utils/analytics'
+import { HERO_SIGNUP_EXPERIMENT } from '~/utils/experiments'
+import { localiseTo } from '~/utils/i18nHref'
+import routes from '~/utils/routes'
+import { extractDomain } from '~/utils/url'
+
+/**
+ * The `variant` arm of the hero signup experiment: instead of a bare "start a
+ * free trial" button, the first step of onboarding happens right here - type
+ * your website, watch the glyph turn into your own favicon, and the signup page
+ * greets you with it. The domain rides along as `?site=`, which the signup
+ * loader immediately moves into a cookie and the onboarding step reads back.
+ *
+ * An empty submit is still a perfectly good "start free trial" click, so we
+ * never block on the field.
+ */
+const HeroSignupForm = () => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation('common')
+  const navigate = useNavigate()
+  const [website, setWebsite] = useState('')
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const domain = extractDomain(website)
+
+    trackCustom('HERO_CTA_CLICK', {
+      variant: HERO_SIGNUP_EXPERIMENT.siteInput,
+      site: domain ? 'entered' : 'empty',
+    })
+
+    navigate(
+      localiseTo(
+        domain
+          ? `${routes.signup}?site=${encodeURIComponent(domain)}`
+          : routes.signup,
+        language,
+      ),
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className='mt-8 flex w-full max-w-xl flex-col items-stretch gap-3 sm:flex-row'
+    >
+      <div className='flex h-12 flex-1 items-center rounded-md bg-white/10 pl-3 ring-1 ring-white/25 backdrop-blur-md transition-colors focus-within:bg-white/15 focus-within:ring-2 focus-within:ring-white/60'>
+        <span className='grid size-5 shrink-0 place-items-center text-gray-200'>
+          <FaviconGlyph value={website} className='size-5' />
+        </span>
+        <input
+          value={website}
+          onChange={(event) => setWebsite(event.target.value)}
+          placeholder='yourwebsite.com'
+          aria-label={t('main.yourWebsite')}
+          autoComplete='url'
+          inputMode='url'
+          className='h-full min-w-0 flex-1 border-0 bg-transparent px-2.5 text-base text-white outline-none placeholder:text-gray-300'
+        />
+      </div>
+      <button
+        type='submit'
+        className='inline-flex h-12 shrink-0 items-center justify-center rounded-md bg-white px-5 text-slate-950 shadow-lg ring-1 shadow-slate-950/20 ring-white/30 transition-colors hover:bg-gray-100'
+      >
+        <span className='text-center text-base font-semibold'>
+          {t('main.addMyWebsite')}
+        </span>
+        <ArrowRightIcon className='mt-[1px] ml-1 h-4 w-5' />
+      </button>
+    </form>
+  )
+}
+
+export default HeroSignupForm

--- a/web/app/pages/Auth/Signup/Signup.tsx
+++ b/web/app/pages/Auth/Signup/Signup.tsx
@@ -28,6 +28,7 @@ import { useTheme } from '~/providers/ThemeProvider'
 import type { SignupActionData } from '~/routes/signup'
 import Button from '~/ui/Button'
 import Checkbox from '~/ui/Checkbox'
+import FaviconGlyph from '~/ui/FaviconGlyph'
 import Input from '~/ui/Input'
 import PasswordStrength from '~/ui/PasswordStrength'
 import { Text } from '~/ui/Text'
@@ -53,7 +54,30 @@ const featureKeys = [
   'intuitive',
 ] as const
 
-const Signup = () => {
+/**
+ * The website the visitor typed on the landing hero, shown back to them with
+ * its own favicon - "yes, we know what you're here to track". Rendered through
+ * <Trans>, so the domain sits wherever the sentence needs it.
+ */
+const SiteChip = ({
+  domain,
+  children,
+}: {
+  domain: string
+  children?: React.ReactNode
+}) => (
+  <span className='inline-flex items-center gap-1.5 align-[-3px] font-medium text-gray-900 dark:text-gray-50'>
+    <FaviconGlyph value={domain} className='size-4' />
+    {children}
+  </span>
+)
+
+interface SignupProps {
+  /** The website typed on the landing hero, if the visitor came in that way. */
+  site?: string | null
+}
+
+const Signup = ({ site = null }: SignupProps) => {
   const { t, i18n } = useTranslation('common')
   const { theme } = useTheme()
   const navigate = useNavigate()
@@ -246,7 +270,18 @@ const Signup = () => {
             </Text>
             {isSelfhosted ? null : (
               <Text as='p' colour='muted' className='mt-2'>
-                {t('auth.signup.trialSubtitle')}
+                {site ? (
+                  <Trans
+                    t={t}
+                    i18nKey='auth.signup.siteSubtitle'
+                    values={{ site }}
+                    components={{
+                      site: <SiteChip domain={site} />,
+                    }}
+                  />
+                ) : (
+                  t('auth.signup.trialSubtitle')
+                )}
               </Text>
             )}
           </div>

--- a/web/app/pages/Onboarding/Onboarding.tsx
+++ b/web/app/pages/Onboarding/Onboarding.tsx
@@ -439,6 +439,7 @@ const Onboarding = () => {
     deviceInfo,
     metainfo,
     onboardingStep: loaderStep,
+    prefill,
   } = useLoaderData<OnboardingLoaderData>()
   const { user, loadUser, logout } = useAuth()
   const navigate = useNavigate()
@@ -455,8 +456,12 @@ const Onboarding = () => {
     return index !== -1 ? index : 0
   })
   const [direction, setDirection] = useState(0)
-  const [projectName, setProjectName] = useState('')
-  const [projectWebsiteUrl, setProjectWebsiteUrl] = useState('')
+  // Prefilled from the landing hero when the visitor already told us their
+  // website there - see `prefill` in the onboarding loader.
+  const [projectName, setProjectName] = useState(prefill?.name || '')
+  const [projectWebsiteUrl, setProjectWebsiteUrl] = useState(
+    prefill?.websiteUrl || '',
+  )
   const [projectTimezone, setProjectTimezone] = useState(() => {
     const userTimezone = user?.timezone
 

--- a/web/app/routes/_index.tsx
+++ b/web/app/routes/_index.tsx
@@ -31,6 +31,7 @@ import useBreakpoint from '~/hooks/useBreakpoint'
 import Button from '~/ui/Button'
 import {
   LIVE_DEMO_URL,
+  isDevelopment,
   isSelfhosted,
   isDisableMarketingPages,
   localisePath,
@@ -41,10 +42,17 @@ import { cn } from '~/utils/generic'
 import routesPath from '~/utils/routes'
 import { getDescription, getPreviewImage, getTitle } from '~/utils/seo'
 import { FeaturesGrid } from '~/components/marketing/FeaturesGrid'
+import HeroSignupForm from '~/components/marketing/HeroSignupForm'
 import { LogoCloud } from '~/components/marketing/LogoCloud'
 import { ScrollReveal } from '~/components/marketing/ScrollReveal'
 import { WhySwitch } from '~/components/marketing/WhySwitch'
 import { Text } from '~/ui/Text'
+import {
+  getExperimentVariant,
+  HERO_SIGNUP_EXPERIMENT_ID,
+} from '~/utils/analytics.server'
+import { trackCustom } from '~/utils/analytics'
+import { HERO_SIGNUP_EXPERIMENT } from '~/utils/experiments'
 
 export const meta: MetaFunction = () => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -66,14 +74,26 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (isSelfhosted || isDisableMarketingPages) {
     return redirect('/login', 302)
   }
-  const [metainfoResult, stats] = await Promise.all([
+  const [metainfoResult, stats, heroVariant] = await Promise.all([
     serverFetch<Metainfo>(request, 'user/metainfo', { skipAuth: true }),
     getGeneralStats(request),
+    // Resolved here so the hero is server-rendered in its final form - the
+    // visitor never sees the control arm flash before the variant swaps in.
+    getExperimentVariant(
+      request,
+      HERO_SIGNUP_EXPERIMENT_ID,
+      HERO_SIGNUP_EXPERIMENT.control,
+    ),
   ])
 
   return {
     metainfo: metainfoResult.data ?? DEFAULT_METAINFO,
     stats,
+    // `?heroVariant=variant` forces an arm locally so both can be eyeballed
+    // without waiting to be bucketed into one. Never honoured in production.
+    heroVariant: isDevelopment
+      ? new URL(request.url).searchParams.get('heroVariant') || heroVariant
+      : heroVariant,
   }
 }
 
@@ -401,6 +421,59 @@ const HeroParallaxBackground = () => {
   )
 }
 
+const HeroCTA = () => {
+  const { t } = useTranslation('common')
+  const { heroVariant } = useLoaderData<typeof loader>()
+
+  const liveDemoButton = (
+    <Button
+      to={LIVE_DEMO_URL}
+      linkProps={{
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      }}
+      variant='secondary'
+      size='xl'
+      className='flex h-12 items-center justify-center border-white/25 bg-white/10 px-5 text-center text-base font-semibold text-white shadow-none ring-white/25 backdrop-blur-md hover:bg-white/20 dark:border-white/25 dark:bg-white/10 dark:text-white dark:hover:bg-white/20'
+      aria-label={`${t('main.seeLiveDemo')} (opens in a new tab)`}
+    >
+      {t('common.liveDemo')}
+    </Button>
+  )
+
+  if (heroVariant === HERO_SIGNUP_EXPERIMENT.siteInput) {
+    return (
+      <div className='flex w-full flex-col items-center'>
+        <HeroSignupForm />
+        <div className='mt-3 flex w-full flex-col items-stretch sm:w-auto'>
+          {liveDemoButton}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className='mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center'>
+      <Link
+        to={routesPath.signup}
+        onClick={() =>
+          trackCustom('HERO_CTA_CLICK', {
+            variant: HERO_SIGNUP_EXPERIMENT.control,
+          })
+        }
+        className='inline-flex h-12 items-center justify-center rounded-md bg-white px-5 text-slate-950 shadow-lg ring-1 shadow-slate-950/20 ring-white/30 transition-colors hover:bg-gray-100'
+        aria-label={t('titles.signup')}
+      >
+        <span className='text-center text-base font-semibold'>
+          {t('main.startAXDayFreeTrial', { amount: 14 })}
+        </span>
+        <ArrowRightIcon className='mt-[1px] ml-1 h-4 w-5' />
+      </Link>
+      {liveDemoButton}
+    </div>
+  )
+}
+
 const Hero = () => {
   const { t } = useTranslation('common')
 
@@ -430,31 +503,7 @@ const Hero = () => {
             >
               {t('main.description')}
             </Text>
-            <div className='mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center'>
-              <Link
-                to={routesPath.signup}
-                className='inline-flex h-12 items-center justify-center rounded-md bg-white px-5 text-slate-950 shadow-lg ring-1 shadow-slate-950/20 ring-white/30 transition-colors hover:bg-gray-100'
-                aria-label={t('titles.signup')}
-              >
-                <span className='text-center text-base font-semibold'>
-                  {t('main.startAXDayFreeTrial', { amount: 14 })}
-                </span>
-                <ArrowRightIcon className='mt-[1px] ml-1 h-4 w-5' />
-              </Link>
-              <Button
-                to={LIVE_DEMO_URL}
-                linkProps={{
-                  target: '_blank',
-                  rel: 'noopener noreferrer',
-                }}
-                variant='secondary'
-                size='xl'
-                className='flex h-12 items-center justify-center border-white/25 bg-white/10 px-5 text-center text-base font-semibold text-white shadow-none ring-white/25 backdrop-blur-md hover:bg-white/20 dark:border-white/25 dark:bg-white/10 dark:text-white dark:hover:bg-white/20'
-                aria-label={`${t('main.seeLiveDemo')} (opens in a new tab)`}
-              >
-                {t('common.liveDemo')}
-              </Button>
-            </div>
+            <HeroCTA />
             <div className='mt-8 flex max-w-4xl flex-wrap justify-center gap-x-16 gap-y-3 text-gray-50'>
               <div className='flex items-center gap-2 text-sm whitespace-nowrap'>
                 <GaugeIcon className='size-5 shrink-0' />

--- a/web/app/routes/onboarding.tsx
+++ b/web/app/routes/onboarding.tsx
@@ -13,6 +13,10 @@ import { DEFAULT_METAINFO, Metainfo } from '~/lib/models/Metainfo'
 import { Project } from '~/lib/models/Project'
 import { User } from '~/lib/models/User'
 import Onboarding from '~/pages/Onboarding'
+import {
+  clearOnboardingSiteCookie,
+  readOnboardingSite,
+} from '~/utils/onboardingSite.server'
 import { getDescription, getPreviewImage, getTitle } from '~/utils/seo'
 import {
   redirectIfNotAuthenticated,
@@ -48,6 +52,12 @@ export interface OnboardingLoaderData {
   }
   metainfo: Metainfo
   onboardingStep: string | null
+  /**
+   * The website typed on the landing hero (hero signup experiment), carried
+   * here in a cookie so the "create your first project" step is already filled
+   * in - nobody gets asked for their site twice.
+   */
+  prefill: { name: string; websiteUrl: string } | null
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -68,6 +78,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       os: parser.getOS().name || null,
     }
   }
+
+  const heroSite = readOnboardingSite(request)
+  const prefill = heroSite
+    ? { name: heroSite, websiteUrl: `https://${heroSite}` }
+    : null
 
   const authResult = await getAuthenticatedUser(request)
   const user = authResult?.user
@@ -115,6 +130,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       deviceInfo,
       metainfo,
       onboardingStep: onboardingStep ?? null,
+      prefill,
     }
 
     if (finalCookies.length > 0) {
@@ -133,6 +149,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         deviceInfo,
         metainfo,
         onboardingStep: onboardingStep ?? null,
+        prefill,
       } as OnboardingLoaderData,
       {
         headers: createHeadersWithCookies(allCookies),
@@ -145,6 +162,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     deviceInfo,
     metainfo,
     onboardingStep: onboardingStep ?? null,
+    prefill,
   } as OnboardingLoaderData
 }
 
@@ -251,6 +269,8 @@ export async function action({ request }: ActionFunctionArgs) {
       }
 
       responseCookies.push(...result.cookies)
+      // The hero handoff has served its purpose now that the project exists.
+      responseCookies.push(clearOnboardingSiteCookie())
 
       return data<OnboardingActionData>(
         {
@@ -302,7 +322,12 @@ export async function action({ request }: ActionFunctionArgs) {
 
       return data<OnboardingActionData>(
         { intent, success: true, user: result.data as User },
-        { headers: createHeadersWithCookies(result.cookies) },
+        {
+          headers: createHeadersWithCookies([
+            ...result.cookies,
+            clearOnboardingSiteCookie(),
+          ]),
+        },
       )
     }
 

--- a/web/app/routes/signup.tsx
+++ b/web/app/routes/signup.tsx
@@ -5,12 +5,22 @@ import type {
   LoaderFunctionArgs,
   MetaFunction,
 } from 'react-router'
-import { redirect, data } from 'react-router'
+import { redirect, data, useLoaderData } from 'react-router'
 import type { SitemapFunction } from 'remix-sitemap'
 
 import { getAuthenticatedUser, registerUser } from '~/api/api.server'
-import { getOgImageUrl, isSelfhosted } from '~/lib/constants'
+import {
+  getOgImageUrl,
+  isSelfhosted,
+  localisedLanguages,
+} from '~/lib/constants'
 import Signup from '~/pages/Auth/Signup'
+import {
+  createOnboardingSiteCookie,
+  onboardingDomainFrom,
+  readOnboardingSite,
+} from '~/utils/onboardingSite.server'
+import routes from '~/utils/routes'
 import { getDescription, getPreviewImage, getTitle } from '~/utils/seo'
 import {
   createHeadersWithCookies,
@@ -41,19 +51,48 @@ export const sitemap: SitemapFunction = () => ({
   exclude: isSelfhosted,
 })
 
+/**
+ * `/signup` when the visitor is already here, keeping the language prefix.
+ * Rebuilt rather than taken from `request.url` - during a client navigation
+ * that's the single-fetch `.data` URL, not something we can redirect to.
+ */
+const selfPath = (url: URL) => {
+  const [, maybeLang] = url.pathname.split('/')
+  const prefix = localisedLanguages.includes(maybeLang) ? `/${maybeLang}` : ''
+
+  const params = new URLSearchParams(url.searchParams)
+  params.delete('site')
+  const query = params.toString()
+
+  return `${prefix}${routes.signup}${query ? `?${query}` : ''}`
+}
+
 export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url)
+  // Landing-hero handoff: the domain typed in the hero arrives as `?site=`.
+  // Move it into a cookie so it survives the SSO popup and the signup POST,
+  // and strip it from the URL so the address bar stays clean.
+  const site = onboardingDomainFrom(url.searchParams.get('site'))
+  const headers = site
+    ? { headers: createHeadersWithCookies([createOnboardingSiteCookie(site)]) }
+    : undefined
+
   const authResult = await getAuthenticatedUser(request)
 
   if (authResult) {
     const user = authResult.user.user
 
     if (!user.hasCompletedOnboarding) {
-      return redirect('/onboarding')
+      return redirect('/onboarding', headers)
     }
-    return redirect('/dashboard')
+    return redirect('/dashboard', headers)
   }
 
-  return null
+  if (url.searchParams.has('site')) {
+    return redirect(selfPath(url), headers)
+  }
+
+  return { site: readOnboardingSite(request) }
 }
 
 export interface SignupActionData {
@@ -115,5 +154,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function SignupPage() {
-  return <Signup />
+  const loaderData = useLoaderData<typeof loader>()
+
+  return <Signup site={loaderData?.site ?? null} />
 }

--- a/web/app/ui/FaviconGlyph.tsx
+++ b/web/app/ui/FaviconGlyph.tsx
@@ -1,0 +1,59 @@
+import { GlobeIcon } from '@phosphor-icons/react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useEffect, useState } from 'react'
+
+import { cn } from '~/utils/generic'
+import { extractDomain } from '~/utils/url'
+
+const DEBOUNCE_MS = 350
+
+interface FaviconGlyphProps {
+  value: string
+  className?: string
+}
+
+/**
+ * The leading glyph of a "your website" input. Once what's being typed resolves
+ * to a plausible domain (debounced, so we don't hammer /api/favicon on every
+ * keystroke) the globe swaps for the site's own favicon - a small, immediate
+ * "we see your site" signal.
+ */
+const FaviconGlyph = ({ value, className }: FaviconGlyphProps) => {
+  const prefersReducedMotion = useReducedMotion()
+  const [domain, setDomain] = useState<string | null>(null)
+
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => setDomain(extractDomain(value)),
+      DEBOUNCE_MS,
+    )
+    return () => clearTimeout(timeout)
+  }, [value])
+
+  return (
+    <AnimatePresence mode='wait' initial={false}>
+      {domain ? (
+        <motion.img
+          key={domain}
+          src={`/api/favicon?domain=${encodeURIComponent(domain)}`}
+          alt=''
+          loading='lazy'
+          initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.6 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.6 }}
+          transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+          // Favicons are drawn for whatever background their own site uses, so
+          // plenty of them are solid black. The white plate keeps them legible
+          // on the dark hero and in dark mode.
+          className={cn('rounded-sm bg-white p-px', className)}
+        />
+      ) : (
+        <motion.span key='globe' initial={false} animate={{ opacity: 1 }}>
+          <GlobeIcon className={className} />
+        </motion.span>
+      )}
+    </AnimatePresence>
+  )
+}
+
+export default FaviconGlyph

--- a/web/app/utils/analytics.server.ts
+++ b/web/app/utils/analytics.server.ts
@@ -12,12 +12,21 @@ const swetrix = new Swetrix(SWETRIX_PID, {
 
 const EXPERIMENT_FETCH_TIMEOUT_MS = 5_000
 
+/**
+ * Hero signup CTA experiment (control: trial button, variant: website input).
+ * Create the experiment in the Swetrix dashboard, link a feature flag to it,
+ * then paste its UUID here or set the env var - an empty value keeps every
+ * visitor on the control arm.
+ */
+export const HERO_SIGNUP_EXPERIMENT_ID =
+  process.env.HERO_SIGNUP_EXPERIMENT_ID || ''
+
 export async function getExperimentVariant(
   request: Request,
   experimentId: string,
   defaultVariant: string | null = null,
 ): Promise<string | null> {
-  if (isSelfhosted) {
+  if (isSelfhosted || !experimentId) {
     return defaultVariant
   }
 

--- a/web/app/utils/experiments.ts
+++ b/web/app/utils/experiments.ts
@@ -1,0 +1,19 @@
+/**
+ * Variant keys for the server-side A/B tests we run on ourselves via Swetrix
+ * experiments. These must match the variant keys of the matching experiment in
+ * the Swetrix dashboard exactly; the experiment IDs themselves live in
+ * `analytics.server.ts` (they're only ever read inside loaders).
+ *
+ * Variants are resolved in the loader, so the page is server-rendered in its
+ * final form - no flash of the control arm, no client-side flicker.
+ */
+
+/**
+ * Hero signup CTA. `control` is the plain "start a free trial" button;
+ * `variant` replaces it with a "type your website" field that carries the
+ * domain through signup and into onboarding.
+ */
+export const HERO_SIGNUP_EXPERIMENT = {
+  control: 'control',
+  siteInput: 'variant',
+} as const

--- a/web/app/utils/onboardingSite.server.ts
+++ b/web/app/utils/onboardingSite.server.ts
@@ -1,0 +1,72 @@
+import { extractDomain } from '~/utils/url'
+
+/**
+ * The landing hero -> signup -> onboarding handoff.
+ *
+ * When a visitor types their website into the hero (the `variant` arm of the
+ * hero signup experiment), the signup loader parks the domain in this
+ * short-lived cookie and strips it from the URL. The onboarding loader reads it
+ * back to prefill the "create your first project" step, so nobody is asked for
+ * their website twice. A cookie (rather than a query param) is what survives
+ * the SSO popup round-trip and the POST-redirect of the email signup form.
+ */
+const COOKIE_NAME = 'swx_onboarding_site'
+const MAX_AGE = 60 * 60 // 1 hour - long enough for a signup, short enough to not linger
+
+const isSecureCookie = () =>
+  process.env.NODE_ENV === 'production' && !process.env.__SELFHOSTED
+
+const parseCookies = (request: Request): Record<string, string> => {
+  const cookieHeader = request.headers.get('Cookie')
+
+  if (!cookieHeader) {
+    return {}
+  }
+
+  const cookies: Record<string, string> = {}
+
+  for (const cookie of cookieHeader.split(';')) {
+    const [name, ...valueParts] = cookie.trim().split('=')
+
+    if (!name) {
+      continue
+    }
+
+    const rawValue = valueParts.join('=')
+
+    try {
+      cookies[name] = decodeURIComponent(rawValue)
+    } catch {
+      cookies[name] = rawValue
+    }
+  }
+
+  return cookies
+}
+
+/** Narrow whatever the visitor typed down to a usable domain, or null. */
+export const onboardingDomainFrom = (raw: string | null | undefined) =>
+  extractDomain(raw)
+
+/** The handoff domain, re-validated on the way out (we don't trust the jar). */
+export const readOnboardingSite = (request: Request) =>
+  onboardingDomainFrom(parseCookies(request)[COOKIE_NAME])
+
+export const createOnboardingSiteCookie = (domain: string) => {
+  const parts = [
+    `${COOKIE_NAME}=${encodeURIComponent(domain)}`,
+    'Path=/',
+    'SameSite=Lax',
+    `Max-Age=${MAX_AGE}`,
+    'HttpOnly',
+  ]
+
+  if (isSecureCookie()) {
+    parts.push('Secure')
+  }
+
+  return parts.join('; ')
+}
+
+export const clearOnboardingSiteCookie = () =>
+  `${COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax; HttpOnly`

--- a/web/app/utils/url.ts
+++ b/web/app/utils/url.ts
@@ -6,3 +6,31 @@ export const isValidHttpUrl = (value: string) => {
     return false
   }
 }
+
+const DOMAIN_REGEX = /^[a-z0-9._-]+\.[a-z]{2,}$/i
+
+/**
+ * Pull a bare hostname out of whatever a visitor typed - with or without a
+ * scheme, `www.`, a path or a trailing dot. Returns null when the input doesn't
+ * (yet) look like a public domain, which is what the callers use to decide
+ * whether it's worth asking for a favicon.
+ */
+export const extractDomain = (raw: string | null | undefined) => {
+  const trimmed = (raw || '').trim().toLowerCase()
+
+  if (!trimmed) {
+    return null
+  }
+
+  const host = trimmed
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .split(/[/?#]/)[0]
+    ?.replace(/\.+$/, '')
+
+  if (!host || host.length > 253 || !DOMAIN_REGEX.test(host)) {
+    return null
+  }
+
+  return host
+}

--- a/web/knip.jsonc
+++ b/web/knip.jsonc
@@ -7,11 +7,11 @@
     "@rrweb/replay",
     "@rrweb/types",
     "dom-player",
-    "@swetrix/node",
+    // "@swetrix/node",
   ],
-  "ignore": [
-    "./app/utils/analytics.server.ts",
-  ],
+  // "ignore": [
+  //   "./app/utils/analytics.server.ts",
+  // ],
   "project": ["./app/**/*.{js,ts,tsx,jsx,cjs}"],
   "paths": {
     "~/*": ["./app/*"],

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -587,6 +587,8 @@
     "description": "Swetrix is a privacy-first Google Analytics alternative that helps you understand visitors, traffic sources and website performance with simple, cookieless, GDPR-compliant insights - no cookie banners or invasive tracking.",
     "understandTheirUsers": "<0>{{amount}}</0> people understand their users",
     "startAXDayFreeTrial": "Start a {{amount}}-day free trial",
+    "addMyWebsite": "Add my website",
+    "yourWebsite": "Your website",
     "metric": "Metric",
     "heroBenefits": {
       "trial": "Free trial {{days}} days",
@@ -745,6 +747,7 @@
       "create": "Create your account",
       "trial": "Start your free {{amount}} day trial",
       "trialSubtitle": "Try all features free. Cancel anytime before your trial ends.",
+      "siteSubtitle": "Create your account and start tracking <site>{{site}}</site> in minutes.",
       "changePlanLater": "You can change your plan later or at any time.",
       "alreadyAMember": "Already a member? <url>Sign in</url>",
       "createAnAccount": "Create an account",


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [ ] Your feature is implemented for the Swetrix Community Edition
- [x] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional website field to the homepage signup experience.
  * Signup can now personalize messaging and display a website favicon.
  * Website details are carried into onboarding to prefill project information.
  * Added experiment-based variations for the homepage signup call to action.
* **Localization**
  * Added English text for website signup and personalized signup messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->